### PR TITLE
Keep security deposit percentage editable on small offers

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferView.java
@@ -928,16 +928,20 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         };
 
         isMinBuyerSecurityDepositListener = ((observable, oldValue, newValue) -> {
-            if (newValue) {
-                // show BTC
-                buyerSecurityDepositPercentageLabel.setText(Res.getBaseCurrencyCode());
-                buyerSecurityDepositInputTextField.setDisable(true);
-            } else {
-                // show %
-                buyerSecurityDepositPercentageLabel.setText("%");
-                buyerSecurityDepositInputTextField.setDisable(false);
-            }
+            updateSecurityDepositLabels();
         });
+    }
+
+    private void updateSecurityDepositLabels() {
+        if (model.isMinBuyerSecurityDeposit.get()) {
+            // show BTC
+            buyerSecurityDepositPercentageLabel.setText(Res.getBaseCurrencyCode());
+            buyerSecurityDepositInputTextField.setDisable(true);
+        } else {
+            // show %
+            buyerSecurityDepositPercentageLabel.setText("%");
+            buyerSecurityDepositInputTextField.setDisable(false);
+        }
     }
 
     private void closeAndGoToOpenOffers() {
@@ -976,6 +980,7 @@ public abstract class MutableOfferView<M extends MutableOfferViewModel<?>> exten
         model.isTradeFeeVisible.addListener(tradeFeeVisibleListener);
         model.buyerSecurityDepositInBTC.addListener(buyerSecurityDepositInBTCListener);
         model.isMinBuyerSecurityDeposit.addListener(isMinBuyerSecurityDepositListener);
+        updateSecurityDepositLabels();
 
         tradeFeeInBtcToggle.selectedProperty().addListener(tradeFeeInBtcToggleListener);
         tradeFeeInBsqToggle.selectedProperty().addListener(tradeFeeInBsqToggleListener);

--- a/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/bisq_v1/MutableOfferViewModel.java
@@ -118,7 +118,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
     public final StringProperty amount = new SimpleStringProperty();
     public final StringProperty minAmount = new SimpleStringProperty();
-    protected final StringProperty buyerSecurityDeposit = new SimpleStringProperty();
+    public final StringProperty buyerSecurityDeposit = new SimpleStringProperty();
     final StringProperty buyerSecurityDepositInBTC = new SimpleStringProperty();
     final StringProperty buyerSecurityDepositLabel = new SimpleStringProperty();
 
@@ -156,7 +156,7 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
     final BooleanProperty showPayFundsScreenDisplayed = new SimpleBooleanProperty();
     private final BooleanProperty showTransactionPublishedScreen = new SimpleBooleanProperty();
     final BooleanProperty isWaitingForFunds = new SimpleBooleanProperty();
-    final BooleanProperty isMinBuyerSecurityDeposit = new SimpleBooleanProperty();
+    public final BooleanProperty isMinBuyerSecurityDeposit = new SimpleBooleanProperty();
 
     final ObjectProperty<InputValidator.ValidationResult> amountValidationResult = new SimpleObjectProperty<>();
     final ObjectProperty<InputValidator.ValidationResult> minAmountValidationResult = new SimpleObjectProperty<>();
@@ -253,6 +253,8 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
 
         addBindings();
         addListeners();
+
+        updateBuyerSecurityDeposit();
 
         updateButtonDisableState();
 
@@ -435,7 +437,10 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
         };
         securityDepositStringListener = (ov, oldValue, newValue) -> {
             if (!ignoreSecurityDepositStringListener) {
-                if (securityDepositValidator.validate(newValue).isValid) {
+                InputValidator.ValidationResult result = securityDepositValidator.validate(newValue);
+                if (!isMinBuyerSecurityDeposit.get())
+                    buyerSecurityDepositValidationResult.set(result);
+                if (result.isValid) {
                     setBuyerSecurityDepositToModel();
                     dataModel.calculateTotalToPay();
                 }
@@ -1327,15 +1332,27 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
         isWaitingForFunds.set(!waitingForFundsText.get().isEmpty());
     }
 
-    private void updateBuyerSecurityDeposit() {
-        isMinBuyerSecurityDeposit.set(dataModel.isMinBuyerSecurityDeposit());
-
-        if (dataModel.isMinBuyerSecurityDeposit()) {
+    protected void updateBuyerSecurityDeposit() {
+        String amountText = amount.get();
+        Coin amountAsCoin = amountText != null && amountText.isEmpty() ? null : dataModel.getAmount().get();
+        double floorAsPercent = amountAsCoin != null && amountAsCoin.isPositive()
+                ? CoinUtil.getAsPercentPerBtc(Restrictions.getMinBuyerSecurityDepositAsCoin(), amountAsCoin)
+                : Double.MAX_VALUE;
+        // >= not >: at exactly the 50% max there is no editable room above the floor, so lock.
+        boolean percentIrrelevant = floorAsPercent >= Restrictions.getMaxBuyerSecurityDepositAsPercent();
+        isMinBuyerSecurityDeposit.set(percentIrrelevant);
+        if (percentIrrelevant) {
             buyerSecurityDepositLabel.set(Res.get("createOffer.minSecurityDepositUsed"));
             buyerSecurityDeposit.set(btcFormatter.formatCoin(Restrictions.getMinBuyerSecurityDepositAsCoin()));
+            buyerSecurityDepositValidationResult.set(new InputValidator.ValidationResult(true));
         } else {
-            buyerSecurityDepositLabel.set(getSecurityDepositLabel());
+            // Percents between the 15% min and the BTC-derived floor stay valid; the data model
+            // floors the actual deposit at the minimum BTC amount, shown via buyerSecurityDepositInBTC.
             buyerSecurityDeposit.set(FormattingUtils.formatToPercent(dataModel.getBuyerSecurityDeposit().get()));
+            buyerSecurityDepositLabel.set(dataModel.isMinBuyerSecurityDeposit()
+                    ? Res.get("createOffer.minSecurityDepositUsed")
+                    : getSecurityDepositLabel());
+            buyerSecurityDepositValidationResult.set(securityDepositValidator.validate(buyerSecurityDeposit.get()));
         }
     }
 
@@ -1353,8 +1370,8 @@ public abstract class MutableOfferViewModel<M extends MutableOfferDataModel> ext
             inputDataValid = inputDataValid && triggerPriceValidationResult.get().isValid;
         }
 
-        // validating the percentage deposit value only makes sense if it is actually used
-        if (!dataModel.isMinBuyerSecurityDeposit()) {
+        // validating the percentage deposit value only makes sense while the field holds a percentage
+        if (!isMinBuyerSecurityDeposit.get()) {
             inputDataValid = inputDataValid && securityDepositValidator.validate(buyerSecurityDeposit.get()).isValid;
         }
 

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/cloneoffer/CloneOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/cloneoffer/CloneOfferViewModel.java
@@ -83,6 +83,7 @@ class CloneOfferViewModel extends MutableOfferViewModel<CloneOfferDataModel> {
         super.activate();
 
         dataModel.populateData();
+        updateBuyerSecurityDeposit();
 
         long triggerPriceAsLong = dataModel.getTriggerPrice();
         dataModel.setTriggerPrice(triggerPriceAsLong);
@@ -113,7 +114,8 @@ class CloneOfferViewModel extends MutableOfferViewModel<CloneOfferDataModel> {
     }
 
     public boolean isSecurityDepositValid() {
-        return securityDepositValidator.validate(buyerSecurityDeposit.get()).isValid;
+        // in the locked state the field holds a fixed BTC amount, not a percentage
+        return isMinBuyerSecurityDeposit.get() || securityDepositValidator.validate(buyerSecurityDeposit.get()).isValid;
     }
 
     @Override

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/editoffer/EditOfferViewModel.java
@@ -83,6 +83,7 @@ class EditOfferViewModel extends MutableOfferViewModel<EditOfferDataModel> {
         super.activate();
 
         dataModel.populateData();
+        updateBuyerSecurityDeposit();
 
         long triggerPriceAsLong = dataModel.getTriggerPrice();
         dataModel.setTriggerPrice(triggerPriceAsLong);
@@ -121,7 +122,8 @@ class EditOfferViewModel extends MutableOfferViewModel<EditOfferDataModel> {
     }
 
     public boolean isSecurityDepositValid() {
-        return securityDepositValidator.validate(buyerSecurityDeposit.get()).isValid;
+        // in the locked state the field holds a fixed BTC amount, not a percentage
+        return isMinBuyerSecurityDeposit.get() || securityDepositValidator.validate(buyerSecurityDeposit.get()).isValid;
     }
 
     @Override

--- a/desktop/src/test/java/bisq/desktop/main/offer/bisq_v1/createoffer/CreateOfferViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/offer/bisq_v1/createoffer/CreateOfferViewModelTest.java
@@ -61,7 +61,9 @@ import org.junit.jupiter.api.Test;
 
 import static bisq.desktop.maker.PreferenceMakers.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -236,5 +238,48 @@ public class CreateOfferViewModelTest {
         assertEquals("0.00", model.marketPriceMargin.get());
         assertEquals("0.00000078", model.volume.get());
         assertEquals("12684.04500000", model.price.get());
+    }
+
+    @Test
+    public void testClearedAmountLocksSecurityDepositAtMin() {
+        assertTrue(model.isMinBuyerSecurityDeposit.get());
+
+        model.amount.set("0.01");
+        assertFalse(model.isMinBuyerSecurityDeposit.get());
+
+        model.amount.set("");
+        assertTrue(model.isMinBuyerSecurityDeposit.get());
+    }
+
+    @Test
+    public void testSecurityDepositLocksOnlyWhenPercentIsIrrelevant() {
+        model.amount.set("0.0005");
+        assertTrue(model.isMinBuyerSecurityDeposit.get());
+
+        model.amount.set("0.01");
+        assertFalse(model.isMinBuyerSecurityDeposit.get());
+    }
+
+    @Test
+    public void testSecurityDepositKeepsPercentWhenFloorApplies() {
+        // Floor well below the min percent: standard 15% shown, editable.
+        model.amount.set("0.01");
+        assertFalse(model.isMinBuyerSecurityDeposit.get());
+        assertEquals("15.00", model.buyerSecurityDeposit.get());
+
+        // Floor works out above the min percent, but the data model floors the actual deposit,
+        // so the displayed percent stays standard instead of being raised to an odd value.
+        model.amount.set("0.001");
+        assertFalse(model.isMinBuyerSecurityDeposit.get());
+        assertEquals("15.00", model.buyerSecurityDeposit.get());
+
+        // Just above the boundary (amounts round to 4 decimals) the floor stays under 50%,
+        // so the field is still editable.
+        model.amount.set("0.0007");
+        assertFalse(model.isMinBuyerSecurityDeposit.get());
+
+        // Floor reaches the 50% max: no editable room left, so the field locks to the min amount.
+        model.amount.set("0.0006");
+        assertTrue(model.isMinBuyerSecurityDeposit.get());
     }
 }

--- a/desktop/src/test/java/bisq/desktop/util/validation/SecurityDepositValidatorTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/validation/SecurityDepositValidatorTest.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.util.validation;
+
+import bisq.core.locale.Res;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SecurityDepositValidatorTest {
+
+    private SecurityDepositValidator validator;
+
+    @BeforeEach
+    public void setup() {
+        Res.setup();
+        validator = new SecurityDepositValidator();
+    }
+
+    @Test
+    public void testValidateWithDefaultMinimum() {
+        assertFalse(validator.validate("14.99").isValid);
+        assertTrue(validator.validate("15.00").isValid);
+        assertTrue(validator.validate("30.00").isValid);
+        assertTrue(validator.validate("50.00").isValid);
+        assertFalse(validator.validate("50.01").isValid);
+
+        assertFalse(validator.validate(null).isValid);
+        assertFalse(validator.validate("").isValid);
+        assertFalse(validator.validate("0").isValid);
+        assertFalse(validator.validate("-15").isValid);
+        assertFalse(validator.validate("abc").isValid);
+    }
+}


### PR DESCRIPTION
The create offer form locks the security deposit input into a fixed
BTC display as soon as the current percentage of the amount does not
exceed the absolute minimum deposit (0.0003 BTC). The lock was added
in #3870 to stop tiny offers from showing misleading giant
percentages (#3868), but it also removed the ability to raise the
deposit: once the field is disabled there is no way to enter a higher
percentage, even though values up to the 50% maximum would still be
meaningful. With the suggested deposit at the 15% minimum this
affects any offer of 0.002 BTC or less.

Keep the field editable whenever a percentage above the floor is
possible:
- The field locks into the fixed BTC display only when percent entry
  is truly irrelevant: no amount entered yet, or the amount so small
  that even the 50% maximum stays below the absolute minimum.
- While editable, SecurityDepositValidator is given the effective
  lower bound (the minimum deposit as a percentage of the current
  amount) and the displayed percentage is floored at that bound, so
  an untouched default is clamped instead of shown as invalid and
  only typed input below the real floor is rejected, with the error
  message naming the limit (that silent lifting to the floor was the
  confusion reported in #3571).
- Since the effective bound depends on the current offer and the
  edit/clone views are cached, the bound is reset in initWithData,
  the deposit state is recomputed after populateData, and the
  isSecurityDepositValid gates treat the locked state as valid.

Unchanged behavior:
- The absolute minimum deposit itself and how the data model floors
  the reserved deposit (getBoundedBuyerSecurityDepositAsCoin).
- The "Min. buyer security deposit is used" label still appears
  whenever the floor binds.
- Offers of 0.002 BTC and above with default settings behave exactly
  as before.

To reproduce on master: create an offer with an amount of 0.001 BTC.
With any deposit percentage at or below 30% the field shows 0.0003
BTC and is disabled, with no way to choose a higher percentage. With
this change the field stays editable and shows the effective floor
(30% for 0.001 BTC); values up to 50% are accepted and lower typed
values are rejected with a message naming the limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved buyer security-deposit behavior while entering offer amounts.
  - Minimum deposits now lock correctly when required, displaying the fixed BTC value.
  - Editable deposits use the appropriate percentage constraints and update immediately.
  - Creating, editing, and cloning offers now handle locked minimum-deposit states correctly.

- **Tests**
  - Added coverage for deposit locking, percentage display, threshold behavior, and invalid deposit values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->