### PR TITLE
Reduce memory pressure on trade statistics screen

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -103,6 +103,7 @@ import javafx.util.StringConverter;
 
 import java.text.DecimalFormat;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
@@ -166,6 +167,9 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
     private TableColumn<TradeStatistics3ListItem, TradeStatistics3ListItem> priceColumn, volumeColumn, marketColumn;
     private SortedList<TradeStatistics3ListItem> sortedList = new SortedList<>(FXCollections.observableArrayList());
+    private Label noDataPlaceholder, processingDataPlaceholder;
+    private boolean activated;
+    private int fillListGeneration;
 
     private ChangeListener<Toggle> timeUnitChangeListener;
     private ChangeListener<Number> priceAxisYWidthListener;
@@ -174,7 +178,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
     private ChangeListener<Number> parentHeightListener;
     private ChangeListener<String> priceColumnLabelListener;
     private ListChangeListener<XYChart.Data<Number, Number>> itemsChangeListener;
-    private ListChangeListener<TradeStatistics3> tradeStatisticsByCurrencyListener;
+    private ChangeListener<Number> tradeStatisticsRevisionListener;
 
     @SuppressWarnings("FieldCanBeLocal")
     private MonadicBinding<Void> currencySelectionBinding;
@@ -244,7 +248,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
             volumeAxisYWidth = (double) newValue;
             layoutChart();
         };
-        tradeStatisticsByCurrencyListener = c -> {
+        tradeStatisticsRevisionListener = (observable, oldValue, newValue) -> {
             nrOfTradeStatisticsLabel.setText(Res.get("market.trades.nrOfTrades", model.tradeStatisticsByCurrency.size()));
             fillList();
         };
@@ -289,6 +293,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
     @Override
     protected void activate() {
+        activated = true;
         tabPaneSelectionModel = GUIUtil.getParentOfType(root, BisqJfxTabPane.class).getSelectionModel();
         selectedTabIndexListener = (observable, oldValue, newValue) -> model.setSelectedTabIndex((int) newValue);
         model.setSelectedTabIndex(tabPaneSelectionModel.getSelectedIndex());
@@ -326,7 +331,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         toggleGroup.selectedToggleProperty().addListener(timeUnitChangeListener);
         priceAxisY.widthProperty().addListener(priceAxisYWidthListener);
         volumeAxisY.widthProperty().addListener(volumeAxisYWidthListener);
-        model.tradeStatisticsByCurrency.addListener(tradeStatisticsByCurrencyListener);
+        model.tradeStatisticsRevision.addListener(tradeStatisticsRevisionListener);
 
         priceAxisY.labelProperty().bind(priceColumnLabel);
         priceColumnLabel.addListener(priceColumnLabelListener);
@@ -339,6 +344,12 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         volumeInUsdChart.setAnimated(useAnimations);
 
         nrOfTradeStatisticsLabel.setText(Res.get("market.trades.nrOfTrades", model.tradeStatisticsByCurrency.size()));
+
+        // The table was released at deactivate and gets rebuilt once the model
+        // has refiltered the data, so we show the processing state meanwhile
+        // and there is nothing to export yet.
+        tableView.setPlaceholder(processingDataPlaceholder);
+        exportLink.setDisable(true);
 
         exportLink.setOnAction(e -> exportToCsv());
 
@@ -363,12 +374,13 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
     @Override
     protected void deactivate() {
+        activated = false;
         tabPaneSelectionModel.selectedIndexProperty().removeListener(selectedTabIndexListener);
         model.priceItems.removeListener(itemsChangeListener);
         toggleGroup.selectedToggleProperty().removeListener(timeUnitChangeListener);
         priceAxisY.widthProperty().removeListener(priceAxisYWidthListener);
         volumeAxisY.widthProperty().removeListener(volumeAxisYWidthListener);
-        model.tradeStatisticsByCurrency.removeListener(tradeStatisticsByCurrencyListener);
+        model.tradeStatisticsRevision.removeListener(tradeStatisticsRevisionListener);
 
         priceAxisY.labelProperty().unbind();
         priceColumnLabel.removeListener(priceColumnLabelListener);
@@ -376,6 +388,16 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         currencySelectionSubscriber.unsubscribe();
 
         sortedList.comparatorProperty().unbind();
+
+        // The view instance is cached by the CachingViewLoader, so we release the
+        // table and volume chart data when leaving the screen. The next activate
+        // rebuilds them and shows the processing placeholder meanwhile. Bumping
+        // the generation discards list builds which are still in flight.
+        fillListGeneration++;
+        tableView.setItems(FXCollections.emptyObservableList());
+        sortedList = new SortedList<>(FXCollections.observableArrayList());
+        volumeSeries.getData().clear();
+        volumeInUsdSeries.getData().clear();
 
         priceSeries.getData().clear();
         priceChart.getData().clear();
@@ -397,26 +419,61 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
     private void fillList() {
         long ts = System.currentTimeMillis();
+        int generation = ++fillListGeneration;
         boolean showAllTradeCurrencies = model.showAllTradeCurrenciesProperty.get();
-        // Collect the list items in reverse chronological order, as this is the likely
-        // order 'sortedList' will place them in - this skips most of its (slow) sorting.
-        CompletableFuture.supplyAsync(() -> Lists.reverse(model.tradeStatisticsByCurrency).stream()
-                .map(tradeStatistics -> new TradeStatistics3ListItem(tradeStatistics,
-                        coinFormatter,
-                        showAllTradeCurrencies))
-                .collect(Collectors.toCollection(FXCollections::observableArrayList))
-        ).whenComplete((listItems, throwable) -> {
-            log.debug("Creating listItems took {} ms", System.currentTimeMillis() - ts);
-
-            long ts2 = System.currentTimeMillis();
-            sortedList.comparatorProperty().unbind();
-            // Sorting is slow as we have > 100k items. So we prefer to do it on the non UI thread.
-            sortedList = new SortedList<>(listItems);
-            sortedList.comparatorProperty().bind(tableView.comparatorProperty());
-            log.debug("Created sorted list took {} ms", System.currentTimeMillis() - ts2);
+        // Snapshot the observable list and the current sort comparator on the user
+        // thread. The background build must not traverse the observable list or read
+        // the table while the user thread can mutate them via setAll or a re-sort.
+        List<TradeStatistics3> snapshot = new ArrayList<>(model.tradeStatisticsByCurrency);
+        Comparator<TradeStatistics3ListItem> comparator = tableView.getComparator();
+        CompletableFuture.supplyAsync(() -> {
+            // Collect the list items in reverse chronological order, as this is the
+            // likely order 'sortedList' will place them in - this skips most of its
+            // (slow) sorting. Sorting is slow as we have > 100k items, so we build
+            // and sort off the UI thread.
+            ObservableList<TradeStatistics3ListItem> listItems = Lists.reverse(snapshot).stream()
+                    .map(tradeStatistics -> new TradeStatistics3ListItem(tradeStatistics,
+                            coinFormatter,
+                            showAllTradeCurrencies))
+                    .collect(Collectors.toCollection(FXCollections::observableArrayList));
+            SortedList<TradeStatistics3ListItem> sorted = new SortedList<>(listItems);
+            if (comparator != null) {
+                sorted.setComparator(comparator);
+            }
+            return sorted;
+        }).whenComplete((newSortedList, throwable) -> {
+            if (throwable != null) {
+                log.error("Error at fillList/creating the list items.", throwable);
+                UserThread.execute(() -> {
+                    if (generation != fillListGeneration) {
+                        return;
+                    }
+                    // Release the previous rows so the failed build does not keep
+                    // stale data attached and exportable behind the placeholder.
+                    sortedList.comparatorProperty().unbind();
+                    sortedList = new SortedList<>(FXCollections.observableArrayList());
+                    tableView.setItems(sortedList);
+                    tableView.setPlaceholder(noDataPlaceholder);
+                    exportLink.setDisable(true);
+                });
+                return;
+            }
+            log.debug("Creating and sorting listItems took {} ms", System.currentTimeMillis() - ts);
             UserThread.execute(() -> {
+                // Discard builds which got overtaken by a deactivate or by a
+                // newer build, so the released table does not get repopulated
+                // on the cached view and a stale list never replaces a fresh one.
+                if (generation != fillListGeneration) {
+                    return;
+                }
+                sortedList.comparatorProperty().unbind();
+                sortedList = newSortedList;
                 // When we attach the list to the table we need to be on the UI thread.
+                // Bind so later header clicks keep re-sorting the list.
+                sortedList.comparatorProperty().bind(tableView.comparatorProperty());
                 tableView.setItems(sortedList);
+                tableView.setPlaceholder(noDataPlaceholder);
+                exportLink.setDisable(false);
             });
         });
     }
@@ -616,6 +673,10 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
     }
 
     private void updateChartData() {
+        // A queued update can arrive after deactivate released the series data.
+        if (!activated) {
+            return;
+        }
         volumeSeries.getData().setAll(model.volumeItems);
         volumeInUsdSeries.getData().setAll(model.volumeInUsdItems);
 
@@ -913,9 +974,11 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         tableView.getColumns().add(paymentMethodColumn);
 
         tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
-        Label placeholder = new AutoTooltipLabel(Res.get("table.placeholder.noData"));
-        placeholder.setWrapText(true);
-        tableView.setPlaceholder(placeholder);
+        noDataPlaceholder = new AutoTooltipLabel(Res.get("table.placeholder.noData"));
+        noDataPlaceholder.setWrapText(true);
+        processingDataPlaceholder = new AutoTooltipLabel(Res.get("table.placeholder.processingData"));
+        processingDataPlaceholder.setWrapText(true);
+        tableView.setPlaceholder(processingDataPlaceholder);
         dateColumn.setSortType(TableColumn.SortType.DESCENDING);
         tableView.getSortOrder().add(dateColumn);
     }

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
@@ -35,6 +35,7 @@ import bisq.core.trade.statistics.TradeStatistics3;
 import bisq.core.trade.statistics.TradeStatisticsManager;
 import bisq.core.user.Preferences;
 
+import bisq.common.Timer;
 import bisq.common.UserThread;
 import bisq.common.util.CompletableFutureUtils;
 
@@ -43,8 +44,10 @@ import com.google.inject.Inject;
 import javafx.scene.chart.XYChart;
 
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleObjectProperty;
 
 import javafx.collections.FXCollections;
@@ -68,6 +71,7 @@ import javax.annotation.Nullable;
 class TradesChartsViewModel extends ActivatableViewModel {
     static final int MAX_TICKS = 90;
     private static final int TAB_INDEX = 2;
+    private static final int CHART_DATA_UPDATE_DELAY_SEC = 10;
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Enum
@@ -94,6 +98,11 @@ class TradesChartsViewModel extends ActivatableViewModel {
     private final CurrencyList currencyListItems;
     private final CurrencyListItem showAllCurrencyListItem = new CurrencyListItem(new CryptoCurrency(GUIUtil.SHOW_ALL_FLAG, ""), -1);
     final ObservableList<TradeStatistics3> tradeStatisticsByCurrency = FXCollections.observableArrayList();
+    // Bumped on the UserThread whenever a refilter result got applied to
+    // tradeStatisticsByCurrency, also when the result was empty or the refilter
+    // failed. setAll does not fire a change event for an empty to empty
+    // transition, so the view listens on this property instead of the list.
+    final IntegerProperty tradeStatisticsRevision = new SimpleIntegerProperty();
     final ObservableList<XYChart.Data<Number, Number>> priceItems = FXCollections.observableArrayList();
     final ObservableList<XYChart.Data<Number, Number>> volumeItems = FXCollections.observableArrayList();
     final ObservableList<XYChart.Data<Number, Number>> volumeInUsdItems = FXCollections.observableArrayList();
@@ -104,6 +113,8 @@ class TradesChartsViewModel extends ActivatableViewModel {
     final Map<TickUnit, Map<Long, Long>> usdAveragePriceMapsPerTickUnit = new HashMap<>();
     private boolean fillTradeCurrenciesOnActivateCalled;
     private volatile boolean deactivateCalled;
+    @Nullable
+    private Timer chartDataUpdateTimer;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -118,20 +129,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
         this.priceFeedService = priceFeedService;
         this.navigation = navigation;
 
-        setChangeListener = change -> {
-            applyAsyncTradeStatisticsForCurrency(getCurrencyCode())
-                    .whenComplete((result, throwable) -> {
-                        if (deactivateCalled) {
-                            return;
-                        }
-                        if (throwable != null) {
-                            log.error("Error at setChangeListener/applyAsyncTradeStatisticsForCurrency. {}", throwable.toString());
-                            return;
-                        }
-                        applyAsyncChartData();
-                    });
-            fillTradeCurrencies();
-        };
+        setChangeListener = change -> scheduleChartDataUpdate();
 
         String tradeChartsScreenCurrencyCode = preferences.getTradeChartsScreenCurrencyCode();
         showAllTradeCurrenciesProperty.set(isShowAllEntry(tradeChartsScreenCurrencyCode));
@@ -188,6 +186,10 @@ class TradesChartsViewModel extends ActivatableViewModel {
     @Override
     protected void deactivate() {
         deactivateCalled = true;
+        if (chartDataUpdateTimer != null) {
+            chartDataUpdateTimer.stop();
+            chartDataUpdateTimer = null;
+        }
         tradeStatisticsManager.getObservableTradeStatisticsSet().removeListener(setChangeListener);
 
         // We want to avoid to trigger listeners in the view so we delay a bit. Deactivate on model is called before
@@ -245,6 +247,9 @@ class TradesChartsViewModel extends ActivatableViewModel {
                     }
                     if (throwable != null) {
                         log.error("Error at applyAsyncTradeStatisticsForCurrency. {}", throwable.toString());
+                        UserThread.execute(() ->
+                                tradeStatisticsRevision.set(tradeStatisticsRevision.get() + 1));
+                        future.completeExceptionally(throwable);
                         if (completeFuture != null) {
                             completeFuture.completeExceptionally(throwable);
                         }
@@ -253,6 +258,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
 
                     UserThread.execute(() -> {
                         tradeStatisticsByCurrency.setAll(list);
+                        tradeStatisticsRevision.set(tradeStatisticsRevision.get() + 1);
                         log.debug("applyAsyncTradeStatisticsForCurrency took {}", System.currentTimeMillis() - ts);
                         if (completeFuture != null) {
                             completeFuture.complete(true);
@@ -365,6 +371,35 @@ class TradesChartsViewModel extends ActivatableViewModel {
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Private
     ///////////////////////////////////////////////////////////////////////////////////////////
+
+    // The observable set fires one change event per arriving trade statistic and
+    // every event re-ran the full chart pipeline including a scan of the whole
+    // data set. Bursts of arriving trade statistics piled up those expensive
+    // rebuilds, so we coalesce the events and rebuild once.
+    private void scheduleChartDataUpdate() {
+        if (chartDataUpdateTimer != null) {
+            return;
+        }
+        chartDataUpdateTimer = UserThread.runAfter(() -> {
+            chartDataUpdateTimer = null;
+            if (deactivateCalled) {
+                return;
+            }
+            applyAsyncTradeStatisticsForCurrency(getCurrencyCode())
+                    .whenComplete((result, throwable) -> {
+                        if (deactivateCalled) {
+                            return;
+                        }
+                        if (throwable != null) {
+                            log.error("Error at scheduleChartDataUpdate/applyAsyncTradeStatisticsForCurrency. {}",
+                                    throwable.toString());
+                            return;
+                        }
+                        applyAsyncChartData();
+                    });
+            fillTradeCurrencies();
+        }, CHART_DATA_UPDATE_DELAY_SEC);
+    }
 
     private void fillTradeCurrencies() {
         // Don't use a set as we need all entries


### PR DESCRIPTION
Part of the OOM mitigation for the trade statistics screen.

The screen re-ran the full chart pipeline once per arriving trade
statistic: the SetChangeListener fired per added item and every
event refiltered the whole data set, rebuilt the chart buckets and
rebuilt the currency list, which scans all trade statistics. With
bursts of arriving trade statistics those expensive rebuilds piled
up and caused large allocation spikes while the screen was open.
The change events are now coalesced with a 10 second timer and
trigger one rebuild. User actions like currency or tick unit
changes do not pass through the debounce and keep updating
immediately.

The view instance is cached by the CachingViewLoader, so the table
with one list item per trade statistic and the volume chart series
stayed retained after leaving the screen, up to a few hundred MB
with "Show all" selected. They are now released at deactivate and
rebuilt at the next activate. While the table rebuilds, the
existing processing data placeholder is shown so the user does not
mistake stale or partial data for the final view, and the CSV
export is disabled until the data is attached.

Implementation notes: the rebuild completion is signalled with a
revision property because ObservableList.setAll does not fire a
change event for an empty to empty transition, which would leave
the processing placeholder stuck for markets without trade
statistics. List builds which got overtaken by a deactivate or by
a newer build are discarded, a failed build falls back to the no
data placeholder, and all timer and flag accesses run on the user
thread, so no additional synchronization is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trade charts and tables when switching views or loading data asynchronously.
  * Prevented outdated results and chart updates from appearing after leaving the view.
  * Added clearer processing and no-data states.
  * Improved error handling and CSV export availability during data loading.

* **Performance**
  * Coalesced chart refreshes to reduce unnecessary updates as trade statistics change.
  * Improved cleanup of chart and table data when leaving the view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->