### PR TITLE
Release the trade statistics table on deactivate

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -165,7 +165,8 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
     private SingleSelectionModel<Tab> tabPaneSelectionModel;
 
     private TableColumn<TradeStatistics3ListItem, TradeStatistics3ListItem> priceColumn, volumeColumn, marketColumn;
-    private SortedList<TradeStatistics3ListItem> sortedList = new SortedList<>(FXCollections.observableArrayList());
+    private volatile SortedList<TradeStatistics3ListItem> sortedList = new SortedList<>(FXCollections.observableArrayList());
+    private volatile boolean deactivateCalled;
 
     private ChangeListener<Toggle> timeUnitChangeListener;
     private ChangeListener<Number> priceAxisYWidthListener;
@@ -289,6 +290,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
     @Override
     protected void activate() {
+        deactivateCalled = false;
         tabPaneSelectionModel = GUIUtil.getParentOfType(root, BisqJfxTabPane.class).getSelectionModel();
         selectedTabIndexListener = (observable, oldValue, newValue) -> model.setSelectedTabIndex((int) newValue);
         model.setSelectedTabIndex(tabPaneSelectionModel.getSelectedIndex());
@@ -363,6 +365,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
     @Override
     protected void deactivate() {
+        deactivateCalled = true;
         tabPaneSelectionModel.selectedIndexProperty().removeListener(selectedTabIndexListener);
         model.priceItems.removeListener(itemsChangeListener);
         toggleGroup.selectedToggleProperty().removeListener(timeUnitChangeListener);
@@ -379,6 +382,11 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
         priceSeries.getData().clear();
         priceChart.getData().clear();
+
+        // Release the large table of list items (one per trade statistic) so it is
+        // not retained while the screen is not shown. It is rebuilt on activate.
+        sortedList = new SortedList<>(FXCollections.observableArrayList());
+        tableView.setItems(sortedList);
 
         exportLink.setOnAction(null);
         showVolumeAsUsdToggleButton.setOnAction(null);
@@ -406,6 +414,11 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                         showAllTradeCurrencies))
                 .collect(Collectors.toCollection(FXCollections::observableArrayList))
         ).whenComplete((listItems, throwable) -> {
+            // We might have left the screen while the list was being built; do not
+            // repopulate the released table on the cached view.
+            if (deactivateCalled) {
+                return;
+            }
             log.debug("Creating listItems took {} ms", System.currentTimeMillis() - ts);
 
             long ts2 = System.currentTimeMillis();
@@ -415,6 +428,14 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
             sortedList.comparatorProperty().bind(tableView.comparatorProperty());
             log.debug("Created sorted list took {} ms", System.currentTimeMillis() - ts2);
             UserThread.execute(() -> {
+                if (deactivateCalled) {
+                    // deactivate ran after we bound the list on the background thread;
+                    // release it instead of attaching it to the cached view.
+                    sortedList.comparatorProperty().unbind();
+                    sortedList = new SortedList<>(FXCollections.observableArrayList());
+                    tableView.setItems(sortedList);
+                    return;
+                }
                 // When we attach the list to the table we need to be on the UI thread.
                 tableView.setItems(sortedList);
             });


### PR DESCRIPTION
The market trade statistics view is kept in the CachingViewLoader
for the whole session. Its table holds one list item per trade
statistic, so with Show all selected it retains the full set,
hundreds of thousands of rows, even while the screen is not shown.
That memory is never released.

This clears the table and drops the sorted list on deactivate so
the rows are collected, and rebuilds them on activate. The async
list build is guarded so a build finishing after the user left
does not repopulate the released table on the cached view.

It does not change the rebuild behavior while the screen is open.
It supersedes #8017, reaching the same goal with a single guard
instead of the debounce and revision machinery there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup when leaving the trade charts view.
  * Prevented stale or detached trade data from being retained or displayed after the view is deactivated.
  * Improved handling of asynchronously loaded trade information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->