### PR TITLE
Fix offer stuck in edit mode after synchronous P2P exception

### DIFF
--- a/core/src/main/java/bisq/core/offer/OfferBookService.java
+++ b/core/src/main/java/bisq/core/offer/OfferBookService.java
@@ -24,6 +24,7 @@ import bisq.core.provider.price.PriceFeedService;
 import bisq.core.util.JsonUtil;
 
 import bisq.network.p2p.BootstrapListener;
+import bisq.network.p2p.NetworkNotReadyException;
 import bisq.network.p2p.P2PService;
 import bisq.network.p2p.storage.HashMapChangedListener;
 import bisq.network.p2p.storage.payload.ProtectedStorageEntry;
@@ -150,7 +151,15 @@ public class OfferBookService {
             return;
         }
 
-        boolean result = p2PService.addProtectedStorageEntry(offer.getOfferPayloadBase());
+        boolean result;
+        try {
+            result = p2PService.addProtectedStorageEntry(offer.getOfferPayloadBase());
+        } catch (NetworkNotReadyException e) {
+            // P2PService throws synchronously while the network is not bootstrapped. Report it
+            // through the error handler so no caller sees an exception bypass its handlers.
+            errorMessageHandler.handleErrorMessage("Add offer failed: the P2P network is not bootstrapped yet");
+            return;
+        }
         if (result) {
             resultHandler.handleResult();
         } else {
@@ -166,7 +175,13 @@ public class OfferBookService {
             return;
         }
 
-        boolean result = p2PService.refreshTTL(offerPayloadBase);
+        boolean result;
+        try {
+            result = p2PService.refreshTTL(offerPayloadBase);
+        } catch (NetworkNotReadyException e) {
+            errorMessageHandler.handleErrorMessage("Refresh TTL failed: the P2P network is not bootstrapped yet.");
+            return;
+        }
         if (result) {
             resultHandler.handleResult();
         } else {
@@ -175,8 +190,8 @@ public class OfferBookService {
     }
 
     public void activateOffer(Offer offer,
-                              @Nullable ResultHandler resultHandler,
-                              @Nullable ErrorMessageHandler errorMessageHandler) {
+                              ResultHandler resultHandler,
+                              ErrorMessageHandler errorMessageHandler) {
         addOffer(offer, resultHandler, errorMessageHandler);
     }
 
@@ -189,7 +204,15 @@ public class OfferBookService {
     public void removeOffer(OfferPayloadBase offerPayloadBase,
                             @Nullable ResultHandler resultHandler,
                             @Nullable ErrorMessageHandler errorMessageHandler) {
-        if (p2PService.removeData(offerPayloadBase)) {
+        boolean removed;
+        try {
+            removed = p2PService.removeData(offerPayloadBase);
+        } catch (NetworkNotReadyException e) {
+            if (errorMessageHandler != null)
+                errorMessageHandler.handleErrorMessage("Remove offer failed: the P2P network is not bootstrapped yet");
+            return;
+        }
+        if (removed) {
             if (resultHandler != null)
                 resultHandler.handleResult();
         } else {
@@ -211,7 +234,10 @@ public class OfferBookService {
     }
 
     public void removeOfferAtShutDown(OfferPayloadBase offerPayloadBase) {
-        removeOffer(offerPayloadBase, null, null);
+        removeOffer(offerPayloadBase,
+                null,
+                errorMessage -> log.warn("Remove offer at shutdown failed, offerId={}, {}",
+                        offerPayloadBase.getId(), errorMessage));
     }
 
     public boolean isBootstrapped() {

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -547,7 +547,8 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                     "We still try to remove it from the offerbook.");
             offerBookService.removeOffer(offer.getOfferPayloadBase(),
                     () -> offer.setState(Offer.State.REMOVED),
-                    null);
+                    errorMessage -> log.warn("Remove offer from offer book failed, offerId={}, {}",
+                            offer.getId(), errorMessage));
         }
     }
 
@@ -601,8 +602,7 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
 
     public void removeOpenOffer(OpenOffer openOffer) {
         removeOpenOffer(openOffer, () -> {
-        }, error -> {
-        });
+        }, errorMessage -> log.warn("Remove open offer failed, offerId={}, {}", openOffer.getId(), errorMessage));
     }
 
     public void removeOpenOffer(OpenOffer openOffer,

--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -90,6 +90,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -353,17 +354,38 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
         }
     }
 
-    public void removeAllOpenOffers(@Nullable Runnable completeHandler) {
-        removeOpenOffers(getObservableList(), completeHandler);
+    // The removal broadcasts are only enqueued here and the aggregated outcome is decided after
+    // a drain delay, reporting failure when any single removal reported one. Callers whose next action
+    // depends on the offers being gone (replacing or emptying the wallet) must abort on the
+    // error path, as a failed removal leaves the offer locally persisted and on the network.
+    public void removeAllOpenOffers(ResultHandler resultHandler, ErrorMessageHandler errorMessageHandler) {
+        removeOpenOffers(getObservableList(), resultHandler, errorMessageHandler);
     }
 
-    private void removeOpenOffers(List<OpenOffer> openOffers, @Nullable Runnable completeHandler) {
+    private void removeOpenOffers(List<OpenOffer> openOffers,
+                                  ResultHandler resultHandler,
+                                  ErrorMessageHandler errorMessageHandler) {
+        checkNotNull(resultHandler, "resultHandler must not be null");
+        checkNotNull(errorMessageHandler, "errorMessageHandler must not be null");
         int size = openOffers.size();
         // Copy list as we remove in the loop
         List<OpenOffer> openOffersList = new ArrayList<>(openOffers);
-        openOffersList.forEach(this::removeOpenOffer);
-        if (completeHandler != null)
-            UserThread.runAfter(completeHandler, size * 200L + 500, TimeUnit.MILLISECONDS);
+        List<String> failedOfferIds = Collections.synchronizedList(new ArrayList<>());
+        openOffersList.forEach(openOffer -> removeOpenOffer(openOffer,
+                () -> {
+                },
+                errorMessage -> {
+                    failedOfferIds.add(openOffer.getId());
+                    log.warn("Remove open offer failed, offerId={}, {}", openOffer.getId(), errorMessage);
+                }));
+        UserThread.runAfter(() -> {
+            if (failedOfferIds.isEmpty()) {
+                resultHandler.handleResult();
+            } else {
+                errorMessageHandler.handleErrorMessage("Offers that could not be removed: "
+                        + String.join(", ", failedOfferIds));
+            }
+        }, size * 200L + 500, TimeUnit.MILLISECONDS);
     }
 
 
@@ -598,11 +620,6 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                     resultHandler.handleResult();
                 },
                 errorMessageHandler);
-    }
-
-    public void removeOpenOffer(OpenOffer openOffer) {
-        removeOpenOffer(openOffer, () -> {
-        }, errorMessage -> log.warn("Remove open offer failed, offerId={}, {}", openOffer.getId(), errorMessage));
     }
 
     public void removeOpenOffer(OpenOffer openOffer,

--- a/core/src/main/java/bisq/core/offer/bsq_swap/OpenBsqSwapOfferService.java
+++ b/core/src/main/java/bisq/core/offer/bsq_swap/OpenBsqSwapOfferService.java
@@ -400,9 +400,17 @@ public class OpenBsqSwapOfferService {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void redoProofOfWorkAndRepublish(OpenOffer openOffer) {
-        // This triggers our onOpenOffersRemoved handler so we don't handle removal here
-        openOfferManager.removeOpenOffer(openOffer);
+        // The removal triggers our onOpenOffersRemoved handler, so we don't handle it here. The
+        // replacement is only minted once the removal succeeded; otherwise the old offer stays
+        // alive next to a mutated-id replacement, as a duplicate on the network. On failure the
+        // offer stays in our list and the next trigger retries the redo.
+        openOfferManager.removeOpenOffer(openOffer,
+                () -> mintAndPublishReplacement(openOffer),
+                errorMessage -> log.warn("Not republishing offer {} as removing it failed: {}",
+                        openOffer.getId(), errorMessage));
+    }
 
+    private void mintAndPublishReplacement(OpenOffer openOffer) {
         String newOfferId = OfferUtil.getOfferIdWithMutationCounter(openOffer.getId());
         NodeAddress nodeAddress = Objects.requireNonNull(openOffer.getOffer().getMakerNodeAddress());
         double difficulty = getPowDifficulty();
@@ -424,7 +432,7 @@ public class OpenBsqSwapOfferService {
                         newOffer.setState(Offer.State.AVAILABLE);
 
                         checkArgument(!openOffer.isDeactivated(),
-                                "We must not get called at redoProofOrWorkAndRepublish if offer was deactivated");
+                                "We must not get called at mintAndPublishReplacement if offer was deactivated");
                         OpenOffer newOpenOffer = new OpenOffer(newOffer);
                         if (!newOpenOffer.isDeactivated()) {
                             openOfferManager.maybeRepublishOffer(newOpenOffer);

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -3054,6 +3054,8 @@ emptyWalletWindow.address=Your destination address
 emptyWalletWindow.button=Send all funds
 emptyWalletWindow.openOffers.warn=You have open offers which will be removed if you empty the wallet.\nAre you sure that you want to empty your wallet?
 emptyWalletWindow.openOffers.yes=Yes, I am sure
+emptyWalletWindow.openOffers.removalFailed=Removing your open offers failed:\n{0}\n\n\
+  No funds have been sent. Resolve the problem, e.g. wait until connected to the P2P network, and try again.
 emptyWalletWindow.sent.success=The balance of your wallet was successfully transferred.
 
 enterPrivKeyWindow.headline=Enter private key for registration
@@ -3773,6 +3775,8 @@ seed.restore.success=Wallets restored successfully with the new seed words.\n\nY
 seed.restore.error=An error occurred when restoring the wallets with seed words.{0}
 seed.restore.openOffers.warn=You have open offers which will be removed if you restore from seed words.\n\
   Are you sure that you want to continue?
+seed.restore.openOffers.removalFailed=Removing your open offers failed:\n{0}\n\n\
+  The wallet was not restored. Resolve the problem, e.g. wait until connected to the P2P network, and try again.
 
 # dynamic values are not recognized by IntelliJ
 # suppress inspection "UnusedProperty"

--- a/core/src/test/java/bisq/core/btc/wallet/TxBroadcasterTest.java
+++ b/core/src/test/java/bisq/core/btc/wallet/TxBroadcasterTest.java
@@ -20,9 +20,9 @@ package bisq.core.btc.wallet;
 import bisq.core.btc.exceptions.TxBroadcastException;
 import bisq.core.btc.nodes.LocalBitcoinNode;
 import bisq.core.btc.wallet.http.MemPoolSpaceTxBroadcaster;
+import bisq.core.testutil.ManualTimer;
 
 import bisq.common.FrameRateTimer;
-import bisq.common.Timer;
 import bisq.common.UserThread;
 
 import org.bitcoinj.core.PeerGroup;
@@ -33,10 +33,6 @@ import org.bitcoinj.wallet.Wallet;
 
 import com.google.common.util.concurrent.SettableFuture;
 
-import java.time.Duration;
-
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -118,14 +114,14 @@ class TxBroadcasterTest {
         ManualTimer secondTimer = ManualTimer.latest();
         firstFuture.set(tx);
 
-        assertFalse(secondTimer.stopped);
+        assertFalse(secondTimer.isStopped());
         assertNull(secondCallback.success.get());
         assertNull(secondCallback.failure.get());
         assertEquals(1, firstCallback.successCount.get());
 
         secondFuture.set(tx);
 
-        assertTrue(secondTimer.stopped);
+        assertTrue(secondTimer.isStopped());
         assertSame(tx, secondCallback.success.get());
         assertEquals(1, secondCallback.successCount.get());
         assertNull(secondCallback.failure.get());
@@ -172,7 +168,7 @@ class TxBroadcasterTest {
 
     private static void assertSynchronousFailureWasCleanedUp(Transaction tx, RecordingCallback failedCallback) {
         ManualTimer failedTimer = ManualTimer.latest();
-        assertTrue(failedTimer.stopped);
+        assertTrue(failedTimer.isStopped());
         failedTimer.fire();
         assertEquals(0, failedCallback.successCount.get());
         assertEquals(0, failedCallback.failureCount.get());
@@ -217,49 +213,4 @@ class TxBroadcasterTest {
         }
     }
 
-    public static class ManualTimer implements Timer {
-        private static final List<ManualTimer> timers = new ArrayList<>();
-
-        private Runnable action;
-        private boolean stopped;
-
-        public ManualTimer() {
-            timers.add(this);
-        }
-
-        @Override
-        public Timer runLater(Duration delay, Runnable action) {
-            this.action = action;
-            return this;
-        }
-
-        @Override
-        public Timer runPeriodically(Duration interval, Runnable action) {
-            this.action = action;
-            return this;
-        }
-
-        @Override
-        public void stop() {
-            stopped = true;
-        }
-
-        private void fire() {
-            if (!stopped) {
-                action.run();
-            }
-        }
-
-        private static ManualTimer latest() {
-            return timers.get(timers.size() - 1);
-        }
-
-        private static void firePendingTimers() {
-            List.copyOf(timers).forEach(ManualTimer::fire);
-        }
-
-        private static void clear() {
-            timers.clear();
-        }
-    }
 }

--- a/core/src/test/java/bisq/core/offer/OfferBookServiceTest.java
+++ b/core/src/test/java/bisq/core/offer/OfferBookServiceTest.java
@@ -1,0 +1,96 @@
+package bisq.core.offer;
+
+import bisq.core.filter.FilterPolicyService;
+import bisq.core.provider.price.PriceFeedService;
+
+import bisq.network.p2p.NetworkNotReadyException;
+import bisq.network.p2p.P2PService;
+
+import bisq.common.handlers.ErrorMessageHandler;
+import bisq.common.handlers.ResultHandler;
+
+import java.nio.file.Files;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static bisq.core.offer.OfferMaker.btcUsdOffer;
+import static com.natpryce.makeiteasy.MakeItEasy.make;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class OfferBookServiceTest {
+    private P2PService p2PService;
+    private OfferBookService service;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        p2PService = mock(P2PService.class);
+        PriceFeedService priceFeedService = mock(PriceFeedService.class);
+        FilterPolicyService filterPolicyService = mock(FilterPolicyService.class);
+        when(filterPolicyService.requireUpdateToNewVersionForTrading()).thenReturn(false);
+        service = new OfferBookService(p2PService,
+                priceFeedService,
+                filterPolicyService,
+                Files.createTempDirectory("storage").toFile(),
+                false);
+    }
+
+    @Test
+    public void testAddOfferReportsSynchronousNetworkNotReadyThroughErrorHandler() {
+        when(p2PService.addProtectedStorageEntry(any())).thenThrow(new NetworkNotReadyException());
+
+        AtomicBoolean resultHandled = new AtomicBoolean(false);
+        AtomicReference<String> error = new AtomicReference<>();
+        service.addOffer(make(btcUsdOffer), () -> resultHandled.set(true), error::set);
+
+        assertEquals("Add offer failed: the P2P network is not bootstrapped yet", error.get());
+        assertFalse(resultHandled.get());
+        verify(p2PService).addProtectedStorageEntry(any());
+    }
+
+    @Test
+    public void testRemoveOfferReportsSynchronousNetworkNotReadyThroughErrorHandler() {
+        when(p2PService.removeData(any())).thenThrow(new NetworkNotReadyException());
+
+        AtomicBoolean resultHandled = new AtomicBoolean(false);
+        AtomicReference<String> error = new AtomicReference<>();
+        service.removeOffer(make(btcUsdOffer).getOfferPayloadBase(), () -> resultHandled.set(true), error::set);
+
+        assertEquals("Remove offer failed: the P2P network is not bootstrapped yet", error.get());
+        assertFalse(resultHandled.get());
+        verify(p2PService).removeData(any());
+    }
+
+    @Test
+    public void testRemoveOfferToleratesMissingHandlersWhenNetworkNotReady() {
+        when(p2PService.removeData(any())).thenThrow(new NetworkNotReadyException());
+
+        assertDoesNotThrow(() ->
+                service.removeOffer(make(btcUsdOffer).getOfferPayloadBase(),
+                        (ResultHandler) null,
+                        (ErrorMessageHandler) null));
+        verify(p2PService).removeData(any());
+    }
+
+    @Test
+    public void testRefreshTTLReportsSynchronousNetworkNotReadyThroughErrorHandler() {
+        when(p2PService.refreshTTL(any())).thenThrow(new NetworkNotReadyException());
+
+        AtomicBoolean resultHandled = new AtomicBoolean(false);
+        AtomicReference<String> error = new AtomicReference<>();
+        service.refreshTTL(make(btcUsdOffer).getOfferPayloadBase(), () -> resultHandled.set(true), error::set);
+
+        assertEquals("Refresh TTL failed: the P2P network is not bootstrapped yet.", error.get());
+        assertFalse(resultHandled.get());
+        verify(p2PService).refreshTTL(any());
+    }
+}

--- a/core/src/test/java/bisq/core/offer/OpenOfferManagerTest.java
+++ b/core/src/test/java/bisq/core/offer/OpenOfferManagerTest.java
@@ -8,6 +8,7 @@ import bisq.core.provider.price.PriceFeedService;
 import bisq.core.trade.model.TradableList;
 import bisq.core.user.Preferences;
 
+import bisq.network.p2p.NetworkNotReadyException;
 import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.P2PService;
 import bisq.network.p2p.peers.PeerManager;
@@ -31,6 +32,8 @@ import org.junit.jupiter.api.Test;
 import static bisq.core.offer.OfferMaker.btcUsdOffer;
 import static com.natpryce.makeiteasy.MakeItEasy.make;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -236,6 +239,115 @@ public class OpenOfferManagerTest {
 
         assertEquals(AvailabilityResult.AVAILABLE, result.availabilityResult);
         verify(offer, never()).getOfferPayload();
+    }
+
+    @Test
+    public void testStartEditOfferClearsEditStateOnDeactivateFailure() {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        when(p2PService.getPeerManager()).thenReturn(mock(PeerManager.class));
+        OpenOfferManager manager = new OpenOfferManager(coreContext,
+                null,
+                null,
+                null,
+                p2PService,
+                null,
+                null,
+                null,
+                offerBookService,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                persistenceManager,
+                null
+        );
+
+        final OpenOffer openOffer = new OpenOffer(make(btcUsdOffer));
+
+        // The offer book service reports a synchronous NetworkNotReadyException from P2PService
+        // through the error handler (converted at that boundary). Without clearing the edit
+        // state this would leave the offer stuck in edit mode until the next restart.
+        doAnswer(invocation -> {
+            ((ErrorMessageHandler) invocation.getArgument(2)).handleErrorMessage("not bootstrapped");
+            return null;
+        }).when(offerBookService).deactivateOffer(any(OfferPayload.class), any(ResultHandler.class), any(ErrorMessageHandler.class));
+
+        AtomicBoolean firstEditErrorHandled = new AtomicBoolean(false);
+        manager.editOpenOfferStart(openOffer, () -> {
+        }, errorMessage -> firstEditErrorHandled.set(true));
+        assertTrue(firstEditErrorHandled.get());
+
+        // Let the second edit's deactivation succeed.
+        doAnswer(invocation -> {
+            ((ResultHandler) invocation.getArgument(1)).handleResult();
+            return null;
+        }).when(offerBookService).deactivateOffer(any(OfferPayload.class), any(ResultHandler.class), any(ErrorMessageHandler.class));
+
+        AtomicBoolean secondEditSuccessful = new AtomicBoolean(false);
+        manager.editOpenOfferStart(openOffer, () -> secondEditSuccessful.set(true), null);
+        assertTrue(secondEditSuccessful.get());
+        // This verify is the assertion that actually distinguishes cleared from leaked state: if
+        // the entry had leaked, the second editOpenOfferStart would short-circuit on the
+        // "already in edit mode" check and never reach deactivateOffer, so it would be called
+        // only once. Two invocations prove the edit state was cleared.
+        verify(offerBookService, times(2)).deactivateOffer(any(OfferPayload.class), any(ResultHandler.class), any(ErrorMessageHandler.class));
+    }
+
+    @Test
+    public void testStartEditOfferDoesNotTreatResultHandlerExceptionAsDeactivationFailure() {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        when(p2PService.getPeerManager()).thenReturn(mock(PeerManager.class));
+        OpenOfferManager manager = new OpenOfferManager(coreContext,
+                null,
+                null,
+                null,
+                p2PService,
+                null,
+                null,
+                null,
+                offerBookService,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                persistenceManager,
+                null
+        );
+
+        final OpenOffer openOffer = new OpenOffer(make(btcUsdOffer));
+
+        doAnswer(invocation -> {
+            ((ResultHandler) invocation.getArgument(1)).handleResult();
+            return null;
+        }).when(offerBookService).deactivateOffer(any(OfferPayload.class), any(ResultHandler.class), any(ErrorMessageHandler.class));
+
+        // The success continuation may itself fail synchronously (e.g. the API edit flow
+        // publishing the edited offer while the network is not ready). That failure must reach
+        // the caller unchanged and must not be reported as a deactivation failure.
+        AtomicBoolean errorHandled = new AtomicBoolean(false);
+        assertThrows(NetworkNotReadyException.class, () ->
+                manager.editOpenOfferStart(openOffer,
+                        () -> {
+                            throw new NetworkNotReadyException();
+                        },
+                        errorMessage -> errorHandled.set(true)));
+        assertFalse(errorHandled.get());
     }
 
 }

--- a/core/src/test/java/bisq/core/offer/OpenOfferManagerTest.java
+++ b/core/src/test/java/bisq/core/offer/OpenOfferManagerTest.java
@@ -1,10 +1,13 @@
 package bisq.core.offer;
 
 import bisq.core.api.CoreContext;
+import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.offer.availability.AvailabilityResult;
 import bisq.core.offer.availability.messages.OfferAvailabilityRequest;
 import bisq.core.offer.bisq_v1.OfferPayload;
 import bisq.core.provider.price.PriceFeedService;
+import bisq.core.testutil.ManualTimer;
+import bisq.core.trade.ClosedTradableManager;
 import bisq.core.trade.model.TradableList;
 import bisq.core.user.Preferences;
 
@@ -13,6 +16,8 @@ import bisq.network.p2p.NodeAddress;
 import bisq.network.p2p.P2PService;
 import bisq.network.p2p.peers.PeerManager;
 
+import bisq.common.FrameRateTimer;
+import bisq.common.UserThread;
 import bisq.common.crypto.PubKeyRing;
 import bisq.common.file.CorruptedStorageFileHandler;
 import bisq.common.handlers.ErrorMessageHandler;
@@ -24,6 +29,7 @@ import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,8 +37,11 @@ import org.junit.jupiter.api.Test;
 
 import static bisq.core.offer.OfferMaker.btcUsdOffer;
 import static com.natpryce.makeiteasy.MakeItEasy.make;
+import static com.natpryce.makeiteasy.MakeItEasy.with;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -299,6 +308,222 @@ public class OpenOfferManagerTest {
         // "already in edit mode" check and never reach deactivateOffer, so it would be called
         // only once. Two invocations prove the edit state was cleared.
         verify(offerBookService, times(2)).deactivateOffer(any(OfferPayload.class), any(ResultHandler.class), any(ErrorMessageHandler.class));
+    }
+
+    @Test
+    public void testRemoveAllOpenOffersReportsAggregatedFailure() {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        when(p2PService.getPeerManager()).thenReturn(mock(PeerManager.class));
+        OpenOfferManager manager = new OpenOfferManager(coreContext,
+                null,
+                null,
+                null,
+                p2PService,
+                mock(BtcWalletService.class),
+                null,
+                null,
+                offerBookService,
+                mock(ClosedTradableManager.class),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                persistenceManager,
+                null
+        );
+        manager.getObservableList().add(new OpenOffer(make(btcUsdOffer)));
+
+        // Every removal fails, e.g. before the P2P network is bootstrapped. The aggregated
+        // outcome must be the error path: a caller about to replace or empty the wallet must
+        // not proceed while the offer is still persisted locally and alive on the network.
+        doAnswer(invocation -> {
+            ((ErrorMessageHandler) invocation.getArgument(2)).handleErrorMessage("not bootstrapped");
+            return null;
+        }).when(offerBookService).removeOffer(any(OfferPayloadBase.class), any(), any(ErrorMessageHandler.class));
+
+        ManualTimer.clear();
+        UserThread.setTimerClass(ManualTimer.class);
+        try {
+            AtomicBoolean completed = new AtomicBoolean(false);
+            AtomicReference<String> errorMessage = new AtomicReference<>();
+            manager.removeAllOpenOffers(() -> completed.set(true), errorMessage::set);
+            ManualTimer.firePendingTimers();
+
+            assertFalse(completed.get());
+            assertNotNull(errorMessage.get());
+            assertEquals(1, manager.getObservableList().size());
+        } finally {
+            ManualTimer.clear();
+            UserThread.setTimerClass(FrameRateTimer.class);
+        }
+    }
+
+    @Test
+    public void testRemoveAllOpenOffersReportsFailureWhenAnySingleRemovalFailed() {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        when(p2PService.getPeerManager()).thenReturn(mock(PeerManager.class));
+        OpenOfferManager manager = new OpenOfferManager(coreContext,
+                null,
+                null,
+                null,
+                p2PService,
+                mock(BtcWalletService.class),
+                null,
+                null,
+                offerBookService,
+                mock(ClosedTradableManager.class),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                persistenceManager,
+                null
+        );
+        OpenOffer failingOffer = new OpenOffer(make(btcUsdOffer));
+        OpenOffer succeedingOffer = new OpenOffer(make(btcUsdOffer.but(with(OfferMaker.id, "5678"))));
+        manager.getObservableList().add(failingOffer);
+        manager.getObservableList().add(succeedingOffer);
+
+        // One removal succeeds, one fails: a single failure must already yield the error
+        // outcome, as the destructive callers need every offer gone.
+        doAnswer(invocation -> {
+            OfferPayloadBase payload = invocation.getArgument(0);
+            if (payload.getId().equals(failingOffer.getId())) {
+                ((ErrorMessageHandler) invocation.getArgument(2)).handleErrorMessage("not bootstrapped");
+            } else {
+                ((ResultHandler) invocation.getArgument(1)).handleResult();
+            }
+            return null;
+        }).when(offerBookService).removeOffer(any(OfferPayloadBase.class), any(), any(ErrorMessageHandler.class));
+
+        ManualTimer.clear();
+        UserThread.setTimerClass(ManualTimer.class);
+        try {
+            AtomicBoolean completed = new AtomicBoolean(false);
+            AtomicReference<String> errorMessage = new AtomicReference<>();
+            manager.removeAllOpenOffers(() -> completed.set(true), errorMessage::set);
+            ManualTimer.firePendingTimers();
+
+            assertFalse(completed.get());
+            assertNotNull(errorMessage.get());
+            assertTrue(errorMessage.get().contains(failingOffer.getId()));
+            assertEquals(1, manager.getObservableList().size());
+            assertEquals(failingOffer.getId(), manager.getObservableList().get(0).getId());
+        } finally {
+            ManualTimer.clear();
+            UserThread.setTimerClass(FrameRateTimer.class);
+        }
+    }
+
+    @Test
+    public void testRemoveAllOpenOffersCompletesOnceAllRemovalsSucceeded() {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        when(p2PService.getPeerManager()).thenReturn(mock(PeerManager.class));
+        OpenOfferManager manager = new OpenOfferManager(coreContext,
+                null,
+                null,
+                null,
+                p2PService,
+                mock(BtcWalletService.class),
+                null,
+                null,
+                offerBookService,
+                mock(ClosedTradableManager.class),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                persistenceManager,
+                null
+        );
+        manager.getObservableList().add(new OpenOffer(make(btcUsdOffer)));
+
+        doAnswer(invocation -> {
+            ((ResultHandler) invocation.getArgument(1)).handleResult();
+            return null;
+        }).when(offerBookService).removeOffer(any(OfferPayloadBase.class), any(), any(ErrorMessageHandler.class));
+
+        ManualTimer.clear();
+        UserThread.setTimerClass(ManualTimer.class);
+        try {
+            AtomicBoolean completed = new AtomicBoolean(false);
+            AtomicReference<String> errorMessage = new AtomicReference<>();
+            manager.removeAllOpenOffers(() -> completed.set(true), errorMessage::set);
+            ManualTimer.firePendingTimers();
+
+            assertTrue(completed.get());
+            assertNull(errorMessage.get());
+            assertTrue(manager.getObservableList().isEmpty());
+        } finally {
+            ManualTimer.clear();
+            UserThread.setTimerClass(FrameRateTimer.class);
+        }
+    }
+
+    @Test
+    public void testRemoveAllOpenOffersWithoutOffersCompletes() {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        when(p2PService.getPeerManager()).thenReturn(mock(PeerManager.class));
+        OpenOfferManager manager = new OpenOfferManager(coreContext,
+                null,
+                null,
+                null,
+                p2PService,
+                mock(BtcWalletService.class),
+                null,
+                null,
+                offerBookService,
+                mock(ClosedTradableManager.class),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                persistenceManager,
+                null
+        );
+
+        ManualTimer.clear();
+        UserThread.setTimerClass(ManualTimer.class);
+        try {
+            AtomicBoolean completed = new AtomicBoolean(false);
+            AtomicReference<String> errorMessage = new AtomicReference<>();
+            manager.removeAllOpenOffers(() -> completed.set(true), errorMessage::set);
+            ManualTimer.firePendingTimers();
+
+            assertTrue(completed.get());
+            assertNull(errorMessage.get());
+        } finally {
+            ManualTimer.clear();
+            UserThread.setTimerClass(FrameRateTimer.class);
+        }
     }
 
     @Test

--- a/core/src/test/java/bisq/core/offer/bsq_swap/OpenBsqSwapOfferServiceTest.java
+++ b/core/src/test/java/bisq/core/offer/bsq_swap/OpenBsqSwapOfferServiceTest.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.offer.bsq_swap;
+
+import bisq.core.btc.wallet.BsqWalletService;
+import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.dao.DaoFacade;
+import bisq.core.filter.FilterManager;
+import bisq.core.filter.FilterPolicyService;
+import bisq.core.offer.Offer;
+import bisq.core.offer.OfferBookService;
+import bisq.core.offer.OfferUtil;
+import bisq.core.offer.OpenOffer;
+import bisq.core.offer.OpenOfferManager;
+import bisq.core.provider.fee.FeeService;
+
+import bisq.network.p2p.P2PService;
+
+import bisq.common.crypto.PubKeyRing;
+import bisq.common.handlers.ErrorMessageHandler;
+import bisq.common.handlers.ResultHandler;
+
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class OpenBsqSwapOfferServiceTest {
+
+    @Test
+    void redoProofOfWorkDoesNotPublishAReplacementWhenTheRemovalFailed() {
+        OpenOfferManager openOfferManager = mock(OpenOfferManager.class);
+        FilterPolicyService filterPolicyService = mock(FilterPolicyService.class);
+        OpenBsqSwapOfferService service = new OpenBsqSwapOfferService(openOfferManager,
+                mock(BtcWalletService.class),
+                mock(BsqWalletService.class),
+                mock(FeeService.class),
+                mock(P2PService.class),
+                mock(DaoFacade.class),
+                mock(OfferBookService.class),
+                mock(OfferUtil.class),
+                mock(FilterManager.class),
+                filterPolicyService,
+                mock(PubKeyRing.class));
+
+        Offer offer = mock(Offer.class);
+        OpenOffer openOffer = mock(OpenOffer.class);
+        when(openOffer.getOffer()).thenReturn(offer);
+        when(openOffer.getId()).thenReturn("offerId");
+        // An invalid proof of work routes the activation into the redo, which replaces the
+        // offer under a mutated id.
+        when(filterPolicyService.isProofOfWorkValid(offer)).thenReturn(false);
+
+        // The removal fails, e.g. before the P2P network is bootstrapped. The old offer then
+        // stays persisted and alive on the network, so no mutated-id replacement may be
+        // published next to it.
+        doAnswer(invocation -> {
+            ((ErrorMessageHandler) invocation.getArgument(2)).handleErrorMessage("not bootstrapped");
+            return null;
+        }).when(openOfferManager).removeOpenOffer(eq(openOffer), any(ResultHandler.class), any(ErrorMessageHandler.class));
+
+        service.activateOpenOffer(openOffer, () -> {
+        }, errorMessage -> {
+        });
+
+        verify(openOfferManager).removeOpenOffer(eq(openOffer), any(ResultHandler.class), any(ErrorMessageHandler.class));
+        verify(openOfferManager, never()).maybeRepublishOffer(any());
+        verify(openOfferManager, never()).addOpenBsqSwapOffer(any());
+    }
+}

--- a/core/src/test/java/bisq/core/testutil/ManualTimer.java
+++ b/core/src/test/java/bisq/core/testutil/ManualTimer.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.testutil;
+
+import bisq.common.Timer;
+
+import java.time.Duration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Deterministic replacement for the UserThread timer in tests: install with
+ * {@code UserThread.setTimerClass(ManualTimer.class)}, fire the collected timers explicitly
+ * and restore {@code FrameRateTimer} afterwards. The collected timers are static state, so
+ * call {@code clear()} around each test for isolation.
+ */
+public class ManualTimer implements Timer {
+    private static final List<ManualTimer> timers = new ArrayList<>();
+
+    private Runnable action;
+    private boolean stopped;
+
+    public ManualTimer() {
+        timers.add(this);
+    }
+
+    @Override
+    public Timer runLater(Duration delay, Runnable action) {
+        this.action = action;
+        return this;
+    }
+
+    @Override
+    public Timer runPeriodically(Duration interval, Runnable action) {
+        this.action = action;
+        return this;
+    }
+
+    @Override
+    public void stop() {
+        stopped = true;
+    }
+
+    public void fire() {
+        if (!stopped) {
+            action.run();
+        }
+    }
+
+    public boolean isStopped() {
+        return stopped;
+    }
+
+    public static ManualTimer latest() {
+        return timers.get(timers.size() - 1);
+    }
+
+    public static void firePendingTimers() {
+        List.copyOf(timers).forEach(ManualTimer::fire);
+    }
+
+    public static void clear() {
+        timers.clear();
+    }
+}

--- a/desktop/src/main/java/bisq/desktop/main/SharedPresentation.java
+++ b/desktop/src/main/java/bisq/desktop/main/SharedPresentation.java
@@ -51,9 +51,10 @@ public class SharedPresentation {
                     new Popup().warning(Res.get("seed.restore.openOffers.warn"))
                             .actionButtonText(Res.get("shared.yes"))
                             .onAction(() -> {
-                                openOfferManager.removeAllOpenOffers(() -> {
-                                    doRestoreSeedWords(walletsManager, seed, storageDir);
-                                });
+                                openOfferManager.removeAllOpenOffers(
+                                        () -> doRestoreSeedWords(walletsManager, seed, storageDir),
+                                        errorMessage -> new Popup().error(
+                                                Res.get("seed.restore.openOffers.removalFailed", errorMessage)).show());
                             })
                             .show(), 100, TimeUnit.MILLISECONDS);
         } else {

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/BtcEmptyWalletWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/BtcEmptyWalletWindow.java
@@ -158,29 +158,36 @@ public final class BtcEmptyWalletWindow extends Overlay<BtcEmptyWalletWindow> {
 
     private void doEmptyWallet2(KeyParameter aesKey) {
         emptyWalletButton.setDisable(true);
-        openOfferManager.removeAllOpenOffers(() -> {
-            try {
-                btcWalletService.emptyBtcWallet(addressInputTextField.getText(),
-                        aesKey,
-                        () -> {
-                            closeButton.updateText(Res.get("shared.close"));
-                            balanceTextField.setText(btcFormatter.formatCoinWithCode(btcWalletService.getAvailableBalance()));
-                            emptyWalletButton.setDisable(true);
-                            log.debug("wallet empty successful");
-                            onClose(() -> UserThread.runAfter(() -> new Popup()
-                                    .feedback(Res.get("emptyWalletWindow.sent.success"))
-                                    .show(), Transitions.DEFAULT_DURATION, TimeUnit.MILLISECONDS));
-                            doClose();
-                        },
-                        (errorMessage) -> {
-                            emptyWalletButton.setDisable(false);
-                            log.error("wallet empty failed {}", errorMessage);
-                        });
-            } catch (InsufficientMoneyException | AddressFormatException e1) {
-                e1.printStackTrace();
-                log.error(e1.getMessage());
-                emptyWalletButton.setDisable(false);
-            }
-        });
+        // Emptying the wallet is only safe once every open offer is gone; a failed removal
+        // leaves the offer locally persisted and on the network, so we abort in that case.
+        openOfferManager.removeAllOpenOffers(() -> doEmptyWallet3(aesKey),
+                errorMessage -> {
+                    emptyWalletButton.setDisable(false);
+                    new Popup().error(Res.get("emptyWalletWindow.openOffers.removalFailed", errorMessage)).show();
+                });
+    }
+
+    private void doEmptyWallet3(KeyParameter aesKey) {
+        try {
+            btcWalletService.emptyBtcWallet(addressInputTextField.getText(),
+                    aesKey,
+                    () -> {
+                        closeButton.updateText(Res.get("shared.close"));
+                        balanceTextField.setText(btcFormatter.formatCoinWithCode(btcWalletService.getAvailableBalance()));
+                        emptyWalletButton.setDisable(true);
+                        log.debug("wallet empty successful");
+                        onClose(() -> UserThread.runAfter(() -> new Popup()
+                                .feedback(Res.get("emptyWalletWindow.sent.success"))
+                                .show(), Transitions.DEFAULT_DURATION, TimeUnit.MILLISECONDS));
+                        doClose();
+                    },
+                    (errorMessage) -> {
+                        emptyWalletButton.setDisable(false);
+                        log.error("wallet empty failed {}", errorMessage);
+                    });
+        } catch (InsufficientMoneyException | AddressFormatException e1) {
+            log.error("wallet empty failed", e1);
+            emptyWalletButton.setDisable(false);
+        }
     }
 }

--- a/docs/specifications/README.md
+++ b/docs/specifications/README.md
@@ -47,6 +47,12 @@ specification says so explicitly instead of describing the implementation as if 
 | [`network/bisq2-bridge-block-continuity.md`](network/bisq2-bridge-block-continuity.md) | Snapshot and live-stream continuity for DAO block data exported to Bisq 2 oracle nodes. |
 | [`network/peer-timestamp-validation.md`](network/peer-timestamp-validation.md) | Overflow-safe freshness validation for peer-controlled protocol timestamps. |
 
+### `offer/`
+
+| Specification | Covers |
+|---|---|
+| [`offer/offer-edit-and-removal.md`](offer/offer-edit-and-removal.md) | The completion contracts of offer edit and removal, and the preconditions they impose on wallet restore, wallet emptying and BSQ swap republishing. |
+
 ### `trade/`
 
 | Specification | Covers |

--- a/docs/specifications/offer/offer-edit-and-removal.md
+++ b/docs/specifications/offer/offer-edit-and-removal.md
@@ -1,0 +1,43 @@
+# Offer edit and removal
+
+## Scope
+
+This specification defines the completion contracts of editing and removing open offers, and the
+preconditions they impose on the destructive flows built on top of them: replacing the wallet,
+emptying the wallet and republishing a BSQ swap offer under a new id.
+
+## Edit
+
+Editing deactivates the offer on the offer book, applies the edit locally and republishes the
+edited offer. A failed deactivation reports the failure and clears the edit state, so the offer
+does not stay stuck in edit mode. A publish failure before the P2P network is bootstrapped does
+not fail the edit: the edit succeeds once the offer is edited locally, and the offer is published
+by the republish that follows the bootstrap. An edit-success report therefore means the offer is
+edited locally and queued for publication, not that it is already visible on the offer book.
+
+## Removal
+
+A successful removal has removed the offer locally, marked it canceled and enqueued the removal
+broadcast; it does not confirm that the network has processed it. A failed removal leaves the
+offer locally persisted and alive on the offer book, where the periodic refresh keeps it from
+expiring.
+
+Removing all open offers aggregates the individual outcomes: the result is success only when
+every single removal succeeded, and the aggregated outcome is decided only after a drain delay
+which gives every removal the chance to report. Any failure yields the error outcome, naming the
+offers which could not be removed.
+
+## Preconditions of destructive flows
+
+Replacing the wallet from seed words and emptying the wallet promise the user that the open
+offers are removed first. Both must abort on the error outcome of the aggregated removal, because
+proceeding would leave offers on the network whose wallet no longer backs them. An offer which is
+currently being edited refuses removal, so these flows abort in that case as well.
+
+A BSQ swap offer whose proof of work became invalid is replaced by a republish under a mutated
+id. The replacement may only be minted and published once the removal of the old offer succeeded;
+otherwise the old offer stays alive next to the replacement as a duplicate. On a failed removal
+the old offer stays in the local list and the next activation retries the redo.
+
+Fire-and-forget removal, reporting a failure only to the log, is acceptable only for callers
+whose subsequent behaviour does not depend on the removal having succeeded.


### PR DESCRIPTION
P2PService throws NetworkNotReadyException synchronously while the network is not bootstrapped. OfferBookService passed that exception through to its callers, bypassing their error handlers: an edit of an active offer then left the offer stuck in edit mode until restart, because editOpenOfferStart never reached the error path clearing offersToBeEdited.

Convert the exception to an operation-specific error message directly at the P2P call in addOffer, removeOffer and refreshTTL. This keeps the handling at the boundary, so an exception thrown by a success callback is not misreported as a failure of the operation itself.

Call sites that passed no-op or null error handlers now log the failure with the offer id: the shutdown removal, the single-argument removeOpenOffer used by removeAllOpenOffers and the wallet-restore path, and the not-in-list removal fallback. Before, a pre-bootstrap failure on those paths disappeared without a trace once the exception no longer reached the global exception handler; on the wallet-restore path that let the restore replace the wallet while the open offers were never withdrawn.

Behaviour note: a pre-bootstrap publish failure in the edit flow now routes into the existing republish retry path instead of aborting the edit, so an API edit returns OK once the offer is edited locally; the offer is published by the bootstrap republish. activateOffer's parameters are no longer marked nullable, matching addOffer which it delegates to.

Covered by OfferBookServiceTest for the three conversions, asserting the exact operation-specific messages and that the P2P call was attempted, and by OpenOfferManagerTest for the edit flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved offer management when the network is unavailable by consistently reporting failures.
* Offer additions, removals, and TTL refreshes now stop safely when network readiness is required.
* Open-offer editing can be retried after deactivation failures.
* Removing all open offers now reports which offers could not be removed.
* Wallet restoration and emptying now stop safely and display an error when offer removal fails.
* BSQ swap offer replacements are no longer published unless the original offer is removed successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->