### PR TITLE
Discard superseded trade statistics async results

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/market/trades/ChartCalculations.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/ChartCalculations.java
@@ -119,7 +119,9 @@ public class ChartCalculations {
             // Generate date range and create sets for all ticks
             List<Pair<Date, Set<TradeStatistics3>>> itemsPerInterval = getItemsPerInterval(tradeStatisticsByCurrency, tickUnit);
 
-            Map<Long, Long> usdAveragePriceMap = usdAveragePriceMapsPerTickUnit.get(tickUnit);
+            // getOrDefault: the map is empty when the chart runs before the USD-average maps are
+            // ready; a missing tick entry then falls back to the previous/zero average below.
+            Map<Long, Long> usdAveragePriceMap = usdAveragePriceMapsPerTickUnit.getOrDefault(tickUnit, Map.of());
             AtomicLong averageUsdPrice = new AtomicLong(0);
 
             // create CandleData for defined time interval

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -166,8 +166,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
     private SingleSelectionModel<Tab> tabPaneSelectionModel;
 
     private TableColumn<TradeStatistics3ListItem, TradeStatistics3ListItem> priceColumn, volumeColumn, marketColumn;
-    private volatile SortedList<TradeStatistics3ListItem> sortedList = new SortedList<>(FXCollections.observableArrayList());
-    private volatile boolean deactivateCalled;
+    private SortedList<TradeStatistics3ListItem> sortedList = new SortedList<>(FXCollections.observableArrayList());
     // Bumped on the user thread at the start of each fillList so a build that
     // finishes after a newer one started, or after the screen was left, is
     // dropped instead of overwriting the published list.
@@ -295,7 +294,6 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
     @Override
     protected void activate() {
-        deactivateCalled = false;
         tabPaneSelectionModel = GUIUtil.getParentOfType(root, BisqJfxTabPane.class).getSelectionModel();
         selectedTabIndexListener = (observable, oldValue, newValue) -> model.setSelectedTabIndex((int) newValue);
         model.setSelectedTabIndex(tabPaneSelectionModel.getSelectedIndex());
@@ -370,7 +368,6 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
     @Override
     protected void deactivate() {
-        deactivateCalled = true;
         // Supersede any build that is still in flight so it cannot publish after
         // the screen is reopened.
         ++fillListGeneration;
@@ -411,15 +408,16 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         volumeInUsdChart.setManaged(showUsd);
     }
 
-    // Build a comparator from the current sort order on the user thread using the
-    // columns' value comparators (which compare plain domain getters). This is used
-    // by the background sort so it does not read any JavaFX state during comparisons.
+    // Build a comparator from the current sort order on the user thread; the background sort uses
+    // it and so reads no JavaFX state during comparisons. Some getters it calls (e.g. getTradePrice)
+    // lazily cache on the shared statistics, which is safe off-thread because each cache just
+    // recomputes an immutable value, so a race only redoes the same work.
     private Comparator<TradeStatistics3ListItem> getSortComparator() {
         Comparator<TradeStatistics3ListItem> result = null;
         for (TableColumn<TradeStatistics3ListItem, ?> column : tableView.getSortOrder()) {
-            // The cast is safe: every sortable column is a
-            // TableColumn<TradeStatistics3ListItem, TradeStatistics3ListItem>
-            // whose comparator was set to a Comparator<TradeStatistics3ListItem>.
+            // Cast is safe only because every sortable column's cellValueFactory returns the row
+            // item itself; a non-identity cellValueFactory in the sort order would instead surface
+            // as a ClassCastException when the background sort invokes the comparator.
             @SuppressWarnings("unchecked")
             Comparator<TradeStatistics3ListItem> columnComparator =
                     (Comparator<TradeStatistics3ListItem>) column.getComparator();
@@ -464,15 +462,17 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
             }
             log.debug("Creating and sorting listItems took {} ms", System.currentTimeMillis() - ts);
             UserThread.execute(() -> {
-                // Publish only if this build is still the current one and the screen
-                // was not left; otherwise drop it so a stale build cannot overwrite a
-                // newer list or repopulate the released table on the cached view.
-                if (deactivateCalled || generation != fillListGeneration) {
+                // Drop the build unless it is still the current one, so it cannot overwrite a newer
+                // list or repopulate the released table. deactivate() bumps fillListGeneration too,
+                // so leaving the screen also drops an in-flight build here.
+                if (generation != fillListGeneration) {
                     return;
                 }
                 sortedList.comparatorProperty().unbind();
                 sortedList = newSortedList;
-                // Bind so later header clicks keep re-sorting the list.
+                // Binding re-sorts once here on the FX thread (SortedList re-sorts on comparator
+                // invalidation); the equivalent-order background pre-sort keeps that pass linear.
+                // The binding also keeps later header clicks re-sorting.
                 sortedList.comparatorProperty().bind(tableView.comparatorProperty());
                 tableView.setItems(sortedList);
             });

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -165,7 +165,8 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
     private SingleSelectionModel<Tab> tabPaneSelectionModel;
 
     private TableColumn<TradeStatistics3ListItem, TradeStatistics3ListItem> priceColumn, volumeColumn, marketColumn;
-    private SortedList<TradeStatistics3ListItem> sortedList = new SortedList<>(FXCollections.observableArrayList());
+    private volatile SortedList<TradeStatistics3ListItem> sortedList = new SortedList<>(FXCollections.observableArrayList());
+    private volatile boolean deactivateCalled;
 
     private ChangeListener<Toggle> timeUnitChangeListener;
     private ChangeListener<Number> priceAxisYWidthListener;
@@ -289,6 +290,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
     @Override
     protected void activate() {
+        deactivateCalled = false;
         tabPaneSelectionModel = GUIUtil.getParentOfType(root, BisqJfxTabPane.class).getSelectionModel();
         selectedTabIndexListener = (observable, oldValue, newValue) -> model.setSelectedTabIndex((int) newValue);
         model.setSelectedTabIndex(tabPaneSelectionModel.getSelectedIndex());
@@ -363,6 +365,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
     @Override
     protected void deactivate() {
+        deactivateCalled = true;
         tabPaneSelectionModel.selectedIndexProperty().removeListener(selectedTabIndexListener);
         model.priceItems.removeListener(itemsChangeListener);
         toggleGroup.selectedToggleProperty().removeListener(timeUnitChangeListener);
@@ -379,6 +382,11 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
 
         priceSeries.getData().clear();
         priceChart.getData().clear();
+
+        // Release the large table of list items (one per trade statistic) so it is
+        // not retained while the screen is not shown. It is rebuilt on activate.
+        sortedList = new SortedList<>(FXCollections.observableArrayList());
+        tableView.setItems(sortedList);
 
         exportLink.setOnAction(null);
         showVolumeAsUsdToggleButton.setOnAction(null);
@@ -406,6 +414,11 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
                         showAllTradeCurrencies))
                 .collect(Collectors.toCollection(FXCollections::observableArrayList))
         ).whenComplete((listItems, throwable) -> {
+            // We might have left the screen while the list was being built; do not
+            // repopulate the released table on the cached view.
+            if (deactivateCalled) {
+                return;
+            }
             log.debug("Creating listItems took {} ms", System.currentTimeMillis() - ts);
 
             long ts2 = System.currentTimeMillis();
@@ -415,6 +428,14 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
             sortedList.comparatorProperty().bind(tableView.comparatorProperty());
             log.debug("Created sorted list took {} ms", System.currentTimeMillis() - ts2);
             UserThread.execute(() -> {
+                if (deactivateCalled) {
+                    // deactivate ran after we bound the list on the background thread;
+                    // release it instead of attaching it to the cached view.
+                    sortedList.comparatorProperty().unbind();
+                    sortedList = new SortedList<>(FXCollections.observableArrayList());
+                    tableView.setItems(sortedList);
+                    return;
+                }
                 // When we attach the list to the table we need to be on the UI thread.
                 tableView.setItems(sortedList);
             });

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -103,6 +103,7 @@ import javafx.util.StringConverter;
 
 import java.text.DecimalFormat;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
@@ -167,6 +168,10 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
     private TableColumn<TradeStatistics3ListItem, TradeStatistics3ListItem> priceColumn, volumeColumn, marketColumn;
     private volatile SortedList<TradeStatistics3ListItem> sortedList = new SortedList<>(FXCollections.observableArrayList());
     private volatile boolean deactivateCalled;
+    // Bumped on the user thread at the start of each fillList so a build that
+    // finishes after a newer one started, or after the screen was left, is
+    // dropped instead of overwriting the published list.
+    private int fillListGeneration;
 
     private ChangeListener<Toggle> timeUnitChangeListener;
     private ChangeListener<Number> priceAxisYWidthListener;
@@ -366,6 +371,9 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
     @Override
     protected void deactivate() {
         deactivateCalled = true;
+        // Supersede any build that is still in flight so it cannot publish after
+        // the screen is reopened.
+        ++fillListGeneration;
         tabPaneSelectionModel.selectedIndexProperty().removeListener(selectedTabIndexListener);
         model.priceItems.removeListener(itemsChangeListener);
         toggleGroup.selectedToggleProperty().removeListener(timeUnitChangeListener);
@@ -403,40 +411,69 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         volumeInUsdChart.setManaged(showUsd);
     }
 
+    // Build a comparator from the current sort order on the user thread using the
+    // columns' value comparators (which compare plain domain getters). This is used
+    // by the background sort so it does not read any JavaFX state during comparisons.
+    private Comparator<TradeStatistics3ListItem> getSortComparator() {
+        Comparator<TradeStatistics3ListItem> result = null;
+        for (TableColumn<TradeStatistics3ListItem, ?> column : tableView.getSortOrder()) {
+            // The cast is safe: every sortable column is a
+            // TableColumn<TradeStatistics3ListItem, TradeStatistics3ListItem>
+            // whose comparator was set to a Comparator<TradeStatistics3ListItem>.
+            @SuppressWarnings("unchecked")
+            Comparator<TradeStatistics3ListItem> columnComparator =
+                    (Comparator<TradeStatistics3ListItem>) column.getComparator();
+            if (columnComparator == null) {
+                continue;
+            }
+            if (column.getSortType() == TableColumn.SortType.DESCENDING) {
+                columnComparator = columnComparator.reversed();
+            }
+            result = result == null ? columnComparator : result.thenComparing(columnComparator);
+        }
+        return result;
+    }
+
     private void fillList() {
         long ts = System.currentTimeMillis();
+        int generation = ++fillListGeneration;
         boolean showAllTradeCurrencies = model.showAllTradeCurrenciesProperty.get();
-        // Collect the list items in reverse chronological order, as this is the likely
-        // order 'sortedList' will place them in - this skips most of its (slow) sorting.
-        CompletableFuture.supplyAsync(() -> Lists.reverse(model.tradeStatisticsByCurrency).stream()
-                .map(tradeStatistics -> new TradeStatistics3ListItem(tradeStatistics,
-                        coinFormatter,
-                        showAllTradeCurrencies))
-                .collect(Collectors.toCollection(FXCollections::observableArrayList))
-        ).whenComplete((listItems, throwable) -> {
-            // We might have left the screen while the list was being built; do not
-            // repopulate the released table on the cached view.
-            if (deactivateCalled) {
+        // Snapshot the observable list and the current sort comparator on the user
+        // thread. The background build must not read the observable list or the
+        // table while the user thread can mutate them via a refilter or a re-sort.
+        List<TradeStatistics3> snapshot = new ArrayList<>(model.tradeStatisticsByCurrency);
+        Comparator<TradeStatistics3ListItem> comparator = getSortComparator();
+        CompletableFuture.supplyAsync(() -> {
+            // Collect the list items in reverse chronological order, as this is the
+            // likely order the sorted list will place them in. Sorting is slow as we
+            // have > 100k items, so we build and sort off the UI thread.
+            ObservableList<TradeStatistics3ListItem> listItems = Lists.reverse(snapshot).stream()
+                    .map(tradeStatistics -> new TradeStatistics3ListItem(tradeStatistics,
+                            coinFormatter,
+                            showAllTradeCurrencies))
+                    .collect(Collectors.toCollection(FXCollections::observableArrayList));
+            SortedList<TradeStatistics3ListItem> sorted = new SortedList<>(listItems);
+            if (comparator != null) {
+                sorted.setComparator(comparator);
+            }
+            return sorted;
+        }).whenComplete((newSortedList, throwable) -> {
+            if (throwable != null) {
+                log.error("Error at fillList/creating the list items.", throwable);
                 return;
             }
-            log.debug("Creating listItems took {} ms", System.currentTimeMillis() - ts);
-
-            long ts2 = System.currentTimeMillis();
-            sortedList.comparatorProperty().unbind();
-            // Sorting is slow as we have > 100k items. So we prefer to do it on the non UI thread.
-            sortedList = new SortedList<>(listItems);
-            sortedList.comparatorProperty().bind(tableView.comparatorProperty());
-            log.debug("Created sorted list took {} ms", System.currentTimeMillis() - ts2);
+            log.debug("Creating and sorting listItems took {} ms", System.currentTimeMillis() - ts);
             UserThread.execute(() -> {
-                if (deactivateCalled) {
-                    // deactivate ran after we bound the list on the background thread;
-                    // release it instead of attaching it to the cached view.
-                    sortedList.comparatorProperty().unbind();
-                    sortedList = new SortedList<>(FXCollections.observableArrayList());
-                    tableView.setItems(sortedList);
+                // Publish only if this build is still the current one and the screen
+                // was not left; otherwise drop it so a stale build cannot overwrite a
+                // newer list or repopulate the released table on the cached view.
+                if (deactivateCalled || generation != fillListGeneration) {
                     return;
                 }
-                // When we attach the list to the table we need to be on the UI thread.
+                sortedList.comparatorProperty().unbind();
+                sortedList = newSortedList;
+                // Bind so later header clicks keep re-sorting the list.
+                sortedList.comparatorProperty().bind(tableView.comparatorProperty());
                 tableView.setItems(sortedList);
             });
         });

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
@@ -104,6 +104,13 @@ class TradesChartsViewModel extends ActivatableViewModel {
     final Map<TickUnit, Map<Long, Long>> usdAveragePriceMapsPerTickUnit = new HashMap<>();
     private boolean fillTradeCurrenciesOnActivateCalled;
     private volatile boolean deactivateCalled;
+    // Each async refilter and chart calculation takes a generation when it starts
+    // on the user thread and applies its result only if the generation is still
+    // current, so a result of a request that was superseded by a newer currency,
+    // tick unit or trade statistics change is dropped instead of overwriting the
+    // newer one. Both counters are read and written only on the user thread.
+    private int refilterGeneration;
+    private int chartGeneration;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -128,7 +135,9 @@ class TradesChartsViewModel extends ActivatableViewModel {
                             log.error("Error at setChangeListener/applyAsyncTradeStatisticsForCurrency. {}", throwable.toString());
                             return;
                         }
-                        applyAsyncChartData();
+                        if (Boolean.TRUE.equals(result)) {
+                            applyAsyncChartData();
+                        }
                     });
             fillTradeCurrencies();
         };
@@ -173,8 +182,11 @@ class TradesChartsViewModel extends ActivatableViewModel {
                         return;
                     }
                     //Once applyAsyncUsdAveragePriceMapsPerTickUnit and applyAsyncTradeStatisticsForCurrency are
-                    // both completed we call applyAsyncChartData
-                    UserThread.execute(this::applyAsyncChartData);
+                    // both completed we call applyAsyncChartData, but only if the refilter was applied
+                    // and not dropped as superseded.
+                    if (task2Done.getNow(false)) {
+                        UserThread.execute(this::applyAsyncChartData);
+                    }
                 });
 
         // We call applyAsyncUsdAveragePriceMapsPerTickUnit and applyAsyncTradeStatisticsForCurrency
@@ -236,6 +248,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
                                                                             @Nullable CompletableFuture<Boolean> completeFuture) {
         CompletableFuture<Boolean> future = new CompletableFuture<>();
         long ts = System.currentTimeMillis();
+        int generation = ++refilterGeneration;
         ChartCalculations.getTradeStatisticsForCurrency(tradeStatisticsManager.getObservableTradeStatisticsSet(),
                         currencyCode,
                         showAllTradeCurrenciesProperty.get())
@@ -245,6 +258,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
                     }
                     if (throwable != null) {
                         log.error("Error at applyAsyncTradeStatisticsForCurrency. {}", throwable.toString());
+                        future.completeExceptionally(throwable);
                         if (completeFuture != null) {
                             completeFuture.completeExceptionally(throwable);
                         }
@@ -252,6 +266,16 @@ class TradesChartsViewModel extends ActivatableViewModel {
                     }
 
                     UserThread.execute(() -> {
+                        if (generation != refilterGeneration) {
+                            // A newer refilter superseded this one, so we drop the
+                            // stale result and complete the futures with false so
+                            // callers do not run a chart update for it.
+                            if (completeFuture != null) {
+                                completeFuture.complete(false);
+                            }
+                            future.complete(false);
+                            return;
+                        }
                         tradeStatisticsByCurrency.setAll(list);
                         log.debug("applyAsyncTradeStatisticsForCurrency took {}", System.currentTimeMillis() - ts);
                         if (completeFuture != null) {
@@ -265,6 +289,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
 
     private void applyAsyncChartData() {
         long ts = System.currentTimeMillis();
+        int generation = ++chartGeneration;
         ChartCalculations.getUpdateChartResult(new ArrayList<>(tradeStatisticsByCurrency),
                         tickUnit,
                         usdAveragePriceMapsPerTickUnit,
@@ -278,6 +303,10 @@ class TradesChartsViewModel extends ActivatableViewModel {
                         return;
                     }
                     UserThread.execute(() -> {
+                        if (generation != chartGeneration) {
+                            // A newer chart calculation superseded this one.
+                            return;
+                        }
                         itemsPerInterval.clear();
                         itemsPerInterval.addAll(updateChartResult.getItemsPerInterval());
 
@@ -323,7 +352,9 @@ class TradesChartsViewModel extends ActivatableViewModel {
                             log.error("Error at onSetTradeCurrency/applyAsyncTradeStatisticsForCurrency. {}", throwable.toString());
                             return;
                         }
-                        applyAsyncChartData();
+                        if (Boolean.TRUE.equals(result)) {
+                            applyAsyncChartData();
+                        }
                     });
         }
     }

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsViewModel.java
@@ -111,6 +111,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
     // newer one. Both counters are read and written only on the user thread.
     private int refilterGeneration;
     private int chartGeneration;
+    private int usdGeneration;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -181,12 +182,10 @@ class TradesChartsViewModel extends ActivatableViewModel {
                         log.error(throwable.toString());
                         return;
                     }
-                    //Once applyAsyncUsdAveragePriceMapsPerTickUnit and applyAsyncTradeStatisticsForCurrency are
-                    // both completed we call applyAsyncChartData, but only if the refilter was applied
-                    // and not dropped as superseded.
-                    if (task2Done.getNow(false)) {
-                        UserThread.execute(this::applyAsyncChartData);
-                    }
+                    // Both tasks completed: recompute the chart. Call it unconditionally - it reads
+                    // the latest tradeStatisticsByCurrency and chartGeneration drops superseded
+                    // results, so gating on task2 would only drop this corrective recompute.
+                    UserThread.execute(this::applyAsyncChartData);
                 });
 
         // We call applyAsyncUsdAveragePriceMapsPerTickUnit and applyAsyncTradeStatisticsForCurrency
@@ -200,6 +199,11 @@ class TradesChartsViewModel extends ActivatableViewModel {
     @Override
     protected void deactivate() {
         deactivateCalled = true;
+        // Bump the generations so any in-flight refilter, chart, or USD-map result is dropped at
+        // publish time instead of repopulating the model after the cleanup below runs.
+        ++refilterGeneration;
+        ++chartGeneration;
+        ++usdGeneration;
         tradeStatisticsManager.getObservableTradeStatisticsSet().removeListener(setChangeListener);
 
         // We want to avoid to trigger listeners in the view so we delay a bit. Deactivate on model is called before
@@ -221,6 +225,7 @@ class TradesChartsViewModel extends ActivatableViewModel {
 
     private void applyAsyncUsdAveragePriceMapsPerTickUnit(CompletableFuture<Boolean> completeFuture) {
         long ts = System.currentTimeMillis();
+        int generation = ++usdGeneration;
         ChartCalculations.getUsdAveragePriceMapsPerTickUnit(tradeStatisticsManager.getNavigableTradeStatisticsSet())
                 .whenComplete((usdAveragePriceMapsPerTickUnit, throwable) -> {
                     if (deactivateCalled) {
@@ -232,6 +237,12 @@ class TradesChartsViewModel extends ActivatableViewModel {
                         return;
                     }
                     UserThread.execute(() -> {
+                        if (generation != usdGeneration) {
+                            // A later activation superseded this result; drop it instead of
+                            // repopulating the model.
+                            completeFuture.complete(false);
+                            return;
+                        }
                         this.usdAveragePriceMapsPerTickUnit.clear();
                         this.usdAveragePriceMapsPerTickUnit.putAll(usdAveragePriceMapsPerTickUnit);
                         log.debug("applyAsyncUsdAveragePriceMapsPerTickUnit took {}", System.currentTimeMillis() - ts);

--- a/desktop/src/test/java/bisq/desktop/main/market/trades/TradesChartsViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/market/trades/TradesChartsViewModelTest.java
@@ -55,6 +55,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -109,12 +110,20 @@ public class TradesChartsViewModelTest {
             1
     );
 
+    private Locale previousLocale;
+
     @BeforeEach
     public void setup() throws IOException {
+        previousLocale = GlobalSettings.getLocale();
         GlobalSettings.setLocale(Locale.US);
         tradeStatisticsManager = mock(TradeStatisticsManager.class);
         model = new TradesChartsViewModel(tradeStatisticsManager, mock(Preferences.class), mock(PriceFeedService.class),
                 mock(Navigation.class));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        GlobalSettings.setLocale(previousLocale);
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/desktop/src/test/java/bisq/desktop/main/market/trades/TradesChartsViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/market/trades/TradesChartsViewModelTest.java
@@ -48,16 +48,20 @@ import java.io.IOException;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 
 public class TradesChartsViewModelTest {
@@ -193,6 +197,34 @@ public class TradesChartsViewModelTest {
         assertEquals(volume, candleData.accumulatedVolume);
         assertEquals(isBullish, candleData.isBullish);
         assertEquals(date, candleData.date);
+    }
+
+    @Test
+    public void getUpdateChartResultToleratesEmptyUsdAveragePriceMaps() {
+        // Regression: a chart update that runs before the USD-average maps are populated must not
+        // NPE on a missing per-tick map. Current timestamp so the trade lands in a non-empty bucket
+        // and the candle path (where the dereference was) runs.
+        String currencyCode = "EUR";
+        List<TradeStatistics3> tradeStatisticsByCurrency = List.of(
+                new TradeStatistics3(currencyCode,
+                        Price.parse(currencyCode, "520").getValue(),
+                        Coin.parseCoin("1").getValue(),
+                        PaymentMethod.BLOCK_CHAINS_ID,
+                        System.currentTimeMillis(),
+                        null,
+                        null,
+                        null,
+                        null));
+
+        Map<TradesChartsViewModel.TickUnit, Map<Long, Long>> emptyUsdAveragePriceMaps = new HashMap<>();
+
+        ChartCalculations.UpdateChartResult result = assertDoesNotThrow(() ->
+                ChartCalculations.getUpdateChartResult(tradeStatisticsByCurrency,
+                        TradesChartsViewModel.TickUnit.DAY,
+                        emptyUsdAveragePriceMaps,
+                        currencyCode).get());
+
+        assertFalse(result.getPriceItems().isEmpty());
     }
 
     // TODO JMOCKIT


### PR DESCRIPTION
Fixes #8018

The trade statistics screen runs asynchronous refilter and chart
calculations in the view model and builds the table rows in the
view, from several triggers: a currency change, a tick unit change,
the trade statistics set change and activate. An older calculation
could complete after a newer request and overwrite the model data,
the chart items or the table with an outdated result.

Each refilter, chart calculation and table build now takes a
generation when it starts on the user thread and applies its result
only if the generation is still current, so superseded results are
dropped. The refilter, the chart and the table build use separate
generations: the refilter and the chart are independent view model
pipelines (a tick unit change bumps only the chart), and the table
build lives in the view, so a single shared counter cannot span
them without cross-invalidating an in-flight build.

The table build also snapshots the observable list and the current
sort comparator on the user thread and sorts off it. Only the pure
per-item column comparators run on the background thread, no scene
graph is read there, which removes the earlier off-thread bind of
the sorted list comparator to the live table property.

This is stacked on #8020.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness and stability when updating trade charts and tables.
  * Prevented outdated trade data, currency filters, and chart calculations from replacing newer results.
  * Improved behavior when leaving and returning to the trade charts view.
  * Ensured rapidly changing currency selections display the latest available results.
  * Preserved error handling while allowing superseded updates to complete safely.
  * Fixed chart updates when USD price data is not yet available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->