### PR TITLE
Avoid materializing a Price per trade statistic

### DIFF
--- a/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsManager.java
+++ b/core/src/main/java/bisq/core/trade/statistics/TradeStatisticsManager.java
@@ -118,10 +118,14 @@ public class TradeStatisticsManager {
                 .filter(TradeStatistics3::isValid)
                 .forEach(observableTradeStatisticsSet::add);
 
-        // get the most recent price for each ccy and notify priceFeedService
-        // (this relies on the trade statistics set being sorted by date)
+        // Seed the most recent price per currency. The set is date-sorted, so iterating
+        // newest-first makes the first entry seen per currency its latest; computeIfAbsent then
+        // calls getTradePrice() only for that row, not every element (putIfAbsent would eval all).
         Map<String, Price> newestPriceByCurrencyCode = new HashMap<>();
-        observableTradeStatisticsSet.forEach(e -> newestPriceByCurrencyCode.put(e.getCurrency(), e.getTradePrice()));
+        for (TradeStatistics3 tradeStatistics : navigableTradeStatisticsSet.descendingSet()) {
+            newestPriceByCurrencyCode.computeIfAbsent(tradeStatistics.getCurrency(),
+                    currencyCode -> tradeStatistics.getTradePrice());
+        }
         priceFeedService.applyInitialBisqMarketPrice(newestPriceByCurrencyCode);
         maybeDumpStatistics();
     }

--- a/core/src/test/java/bisq/core/trade/statistics/TradeStatisticsManagerTest.java
+++ b/core/src/test/java/bisq/core/trade/statistics/TradeStatisticsManagerTest.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.trade.statistics;
+
+import bisq.core.locale.GlobalSettings;
+import bisq.core.monetary.Price;
+import bisq.core.provider.price.PriceFeedService;
+
+import bisq.network.p2p.P2PService;
+import bisq.network.p2p.storage.P2PDataStorage;
+import bisq.network.p2p.storage.payload.PersistableNetworkPayload;
+import bisq.network.p2p.storage.persistence.AppendOnlyDataStoreService;
+
+import org.bitcoinj.core.Coin;
+
+import java.io.File;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TradeStatisticsManagerTest {
+    private Locale previousLocale;
+
+    @BeforeEach
+    public void setup() {
+        previousLocale = GlobalSettings.getLocale();
+        GlobalSettings.setLocale(Locale.US);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        GlobalSettings.setLocale(previousLocale);
+    }
+
+    @Test
+    public void seedsNewestPricePerCurrencyIntoPriceFeed() {
+        // Two USD statistics; the newer date carries a different price. The seeding must select
+        // the newest price per currency, which relies on the set being ordered by date first.
+        long amount = Coin.parseCoin("0.25").getValue();
+        TradeStatistics3 older = new TradeStatistics3("USD", Price.parse("USD", "100").getValue(),
+                amount, "SEPA", 1_700_000_000_000L, null, null, null, null);
+        TradeStatistics3 newer = new TradeStatistics3("USD", Price.parse("USD", "200").getValue(),
+                amount, "SEPA", 1_700_000_100_000L, null, null, null, null);
+
+        TradeStatistics3StorageService storageService = mock(TradeStatistics3StorageService.class);
+        Map<P2PDataStorage.ByteArray, PersistableNetworkPayload> mapOfAllData = new HashMap<>();
+        mapOfAllData.put(new P2PDataStorage.ByteArray(new byte[]{1}), older);
+        mapOfAllData.put(new P2PDataStorage.ByteArray(new byte[]{2}), newer);
+        when(storageService.getMapOfAllData()).thenReturn(mapOfAllData);
+
+        P2PService p2PService = mock(P2PService.class);
+        when(p2PService.getP2PDataStorage()).thenReturn(mock(P2PDataStorage.class));
+        PriceFeedService priceFeedService = mock(PriceFeedService.class);
+
+        TradeStatisticsManager manager = new TradeStatisticsManager(p2PService, priceFeedService,
+                storageService, mock(AppendOnlyDataStoreService.class), new File("."), false);
+
+        manager.onAllServicesInitialized();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Price>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(priceFeedService).applyInitialBisqMarketPrice(captor.capture());
+        assertEquals(newer.getTradePrice().getValue(), captor.getValue().get("USD").getValue());
+    }
+}


### PR DESCRIPTION
onAllServicesInitialized seeds PriceFeedService with the newest price
per currency by calling getTradePrice() on every trade statistic.
getTradePrice() lazily builds and caches a Price on the element, so the
loop pinned a Price (plus its Monetary) on every row for the whole
session, although only the latest price per currency is used.

The statistics set is sorted by date, so this iterates it newest-first
and keeps the first price seen per currency with computeIfAbsent. The
resulting map is identical (the set is a TreeSet with a total order, so
descending-first-wins selects the same element per currency as the
previous ascending forEach with last-write-wins), but getTradePrice()
runs once per currency instead of once per element.

Measured on a full mainnet store: retained Price instances at startup
dropped from about 410k to a few hundred, roughly 19 MB less, before
the Market -> Trades screen is opened. No behavior change; the seed map is
identical and is refreshed by the live price feed as before.

putIfAbsent and a toMap collector were avoided on purpose: both evaluate
getTradePrice() for every element, which is exactly the materialization
this change removes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initial market price selection by using the latest available trade statistics for each currency.
  * Prevented older trade data from incorrectly overriding newer market prices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->