### PR TITLE
Check isPubKeyValid only for own mailbox messages

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/TradeProtocol.java
@@ -142,9 +142,11 @@ public abstract class TradeProtocol implements DecryptedDirectMessageListener, D
 
     private void handleMailboxCollection(Collection<DecryptedMessageWithPubKey> collection) {
         collection.stream()
+                // Check isMyMessage before isPubKeyValid so we do not validate (and log a
+                // mismatch for) messages addressed to other trades, as onDirectMessage does.
+                .filter(message -> isMyMessage(message.getNetworkEnvelope()))
                 .filter(this::isPubKeyValid)
                 .map(DecryptedMessageWithPubKey::getNetworkEnvelope)
-                .filter(this::isMyMessage)
                 .filter(e -> e instanceof MailboxMessage)
                 .map(e -> (MailboxMessage) e)
                 .forEach(this::handleMailboxMessage);


### PR DESCRIPTION
Each trade's protocol registers as a mailbox listener, so every mailbox
message is handed to every protocol. handleMailboxCollection ran
isPubKeyValid before isMyMessage, so each protocol logged a pubkey
mismatch for messages addressed to other trades. On a node with many
trades that floods the log, mostly at startup, with "SignaturePubKey in
message does not match the SignaturePubKey we have set for our trading
peer".

Check isMyMessage first, as onDirectMessage already does. The set of
messages reaching handleMailboxMessage is unchanged (the pass condition
is the same conjunction); only the erroneous mismatch log for other
trades messages is removed. A mismatch on one of our own messages is
still logged and dropped.

This completes 4afa846a1c, which applied the same fix to the direct
message path but not the mailbox path, so the logging reported in #5194
persisted for mailbox messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trade message filtering to ignore messages intended for other trades before validating their public keys.
  * Prevented unnecessary public-key mismatch warnings for unrelated trade messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->