### PR TITLE
Fix bug with repeated broadcast

### DIFF
--- a/core/src/main/java/bisq/core/btc/wallet/TxBroadcaster.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TxBroadcaster.java
@@ -33,8 +33,8 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -83,7 +83,7 @@ public class TxBroadcaster {
     // For trade fee txs we set only 1 sec timeout for now.
     // FIXME
     private static final int DEFAULT_BROADCAST_TIMEOUT = 5;
-    private static final Map<String, Timer> broadcastTimerMap = new HashMap<>();
+    private static final Map<String, BroadcastRequest> broadcastRequestMap = new ConcurrentHashMap<>();
 
     public static void broadcastTx(Wallet wallet, PeerGroup peerGroup, Transaction localTx, Callback callback) {
         broadcastTx(wallet, peerGroup, localTx, callback, DEFAULT_BROADCAST_TIMEOUT);
@@ -92,7 +92,8 @@ public class TxBroadcaster {
     public static void broadcastTx(Wallet wallet, PeerGroup peerGroup, Transaction tx, Callback callback, int timeOut) {
         final String txId = tx.getTxId().toString();
         log.info("Broadcast transaction with ID: {}. Serialized tx: {}", txId, Utils.HEX.encode(tx.bitcoinSerialize()));
-        if (broadcastTimerMap.containsKey(txId)) {
+        BroadcastRequest request = new BroadcastRequest();
+        if (broadcastRequestMap.putIfAbsent(txId, request) != null) {
             // Would be the wrong way how to use the API (calling 2 times a broadcast with same tx).
             // An arbitrator reported that got the error after a manual payout, need to investigate why...
             // We must not touch the state of the pending broadcast here. Removing its timeout timer would leave the
@@ -106,52 +107,74 @@ public class TxBroadcaster {
             return;
         }
 
-        Timer timeoutTimer = UserThread.runAfter(() -> {
-            log.warn("Broadcast of tx {} not completed after {} sec.", txId, timeOut);
-            stopAndRemoveTimer(txId);
-            UserThread.execute(() -> callback.onTimeout(new TxBroadcastTimeoutException(tx, timeOut, wallet)));
-        }, timeOut);
-
-        broadcastTimerMap.put(txId, timeoutTimer);
-
-        // We decided the least risky scenario is to commit the tx to the wallet and broadcast it later.
-        // If it's a bsq tx WalletManager.publishAndCommitBsqTx() should have committed the tx to both bsq and btc
-        // wallets so the next line causes no effect.
-        // If it's a btc tx, the next line adds the tx to the wallet.
-        wallet.maybeCommitTx(tx);
-
-        Futures.addCallback(peerGroup.broadcastTransaction(tx).future(), new FutureCallback<>() {
-            @Override
-            public void onSuccess(@Nullable Transaction result) {
-                // We expect that there is still a timeout in our map, otherwise the timeout got triggered
-                if (broadcastTimerMap.containsKey(txId)) {
-                    stopAndRemoveTimer(txId);
-                    // At regtest we get called immediately back but we want to make sure that the handler is not called
-                    // before the caller is finished.
-                    UserThread.execute(() -> callback.onSuccess(tx));
-                } else {
-                    log.warn("We got an onSuccess callback for a broadcast which already triggered the timeout. txId={}", txId);
+        try {
+            request.setTimeoutTimer(UserThread.runAfter(() -> {
+                if (stopAndRemoveRequest(txId, request)) {
+                    log.warn("Broadcast of tx {} not completed after {} sec.", txId, timeOut);
+                    UserThread.execute(() -> callback.onTimeout(new TxBroadcastTimeoutException(tx, timeOut, wallet)));
                 }
-            }
+            }, timeOut));
 
-            @Override
-            public void onFailure(@NotNull Throwable throwable) {
-                stopAndRemoveTimer(txId);
-                UserThread.execute(() -> callback.onFailure(new TxBroadcastException("We got an onFailure from " +
-                        "the peerGroup.broadcastTransaction callback.", throwable)));
-            }
-        }, MoreExecutors.directExecutor());
+            // We decided the least risky scenario is to commit the tx to the wallet and broadcast it later.
+            // If it's a bsq tx WalletManager.publishAndCommitBsqTx() should have committed the tx to both bsq and btc
+            // wallets so the next line causes no effect.
+            // If it's a btc tx, the next line adds the tx to the wallet.
+            wallet.maybeCommitTx(tx);
+
+            Futures.addCallback(peerGroup.broadcastTransaction(tx).future(), new FutureCallback<>() {
+                @Override
+                public void onSuccess(@Nullable Transaction result) {
+                    if (stopAndRemoveRequest(txId, request)) {
+                        // At regtest we get called immediately back but we want to make sure that the handler is not
+                        // called before the caller is finished.
+                        UserThread.execute(() -> callback.onSuccess(tx));
+                    } else {
+                        log.warn("We got an onSuccess callback for a broadcast which already completed. txId={}", txId);
+                    }
+                }
+
+                @Override
+                public void onFailure(@NotNull Throwable throwable) {
+                    if (stopAndRemoveRequest(txId, request)) {
+                        UserThread.execute(() -> callback.onFailure(new TxBroadcastException("We got an onFailure " +
+                                "from the peerGroup.broadcastTransaction callback.", throwable)));
+                    } else {
+                        log.warn("We got an onFailure callback for a broadcast which already completed. txId={}", txId);
+                    }
+                }
+            }, MoreExecutors.directExecutor());
+        } catch (RuntimeException | Error throwable) {
+            stopAndRemoveRequest(txId, request);
+            throw throwable;
+        }
 
         // For better redundancy in case the broadcast via BitcoinJ fails we also
         // publish the tx via mempool nodes.
         MemPoolSpaceTxBroadcaster.broadcastTx(tx);
     }
 
-    private static void stopAndRemoveTimer(String txId) {
-        Timer timer = broadcastTimerMap.get(txId);
-        if (timer != null)
-            timer.stop();
+    private static boolean stopAndRemoveRequest(String txId, BroadcastRequest request) {
+        if (!broadcastRequestMap.remove(txId, request)) {
+            return false;
+        }
 
-        broadcastTimerMap.remove(txId);
+        request.stopTimeoutTimer();
+        return true;
+    }
+
+    private static class BroadcastRequest {
+        @Nullable
+        private volatile Timer timeoutTimer;
+
+        private void setTimeoutTimer(Timer timeoutTimer) {
+            this.timeoutTimer = timeoutTimer;
+        }
+
+        private void stopTimeoutTimer() {
+            Timer timer = timeoutTimer;
+            if (timer != null) {
+                timer.stop();
+            }
+        }
     }
 }

--- a/core/src/main/java/bisq/core/btc/wallet/TxBroadcaster.java
+++ b/core/src/main/java/bisq/core/btc/wallet/TxBroadcaster.java
@@ -90,24 +90,29 @@ public class TxBroadcaster {
     }
 
     public static void broadcastTx(Wallet wallet, PeerGroup peerGroup, Transaction tx, Callback callback, int timeOut) {
-        Timer timeoutTimer;
         final String txId = tx.getTxId().toString();
         log.info("Broadcast transaction with ID: {}. Serialized tx: {}", txId, Utils.HEX.encode(tx.bitcoinSerialize()));
-        if (!broadcastTimerMap.containsKey(txId)) {
-            timeoutTimer = UserThread.runAfter(() -> {
-                log.warn("Broadcast of tx {} not completed after {} sec.", txId, timeOut);
-                stopAndRemoveTimer(txId);
-                UserThread.execute(() -> callback.onTimeout(new TxBroadcastTimeoutException(tx, timeOut, wallet)));
-            }, timeOut);
-
-            broadcastTimerMap.put(txId, timeoutTimer);
-        } else {
+        if (broadcastTimerMap.containsKey(txId)) {
             // Would be the wrong way how to use the API (calling 2 times a broadcast with same tx).
             // An arbitrator reported that got the error after a manual payout, need to investigate why...
-            stopAndRemoveTimer(txId);
+            // We must not touch the state of the pending broadcast here. Removing its timeout timer would leave the
+            // first caller without any callback: the timeout can no longer fire and the peer group success handler
+            // below skips a broadcast whose timer is gone. The caller would then never learn that its transaction
+            // was published, even though the transaction is committed to the wallet and propagated to the network.
+            // We therefore only report the misuse to the second caller and leave the pending broadcast alone.
+            // Committing and broadcasting again is not needed either, as the first call already did both.
             UserThread.execute(() -> callback.onFailure(new TxBroadcastException("We got broadcastTx called with a tx " +
                     "which has an open timeoutTimer. txId=" + txId, txId)));
+            return;
         }
+
+        Timer timeoutTimer = UserThread.runAfter(() -> {
+            log.warn("Broadcast of tx {} not completed after {} sec.", txId, timeOut);
+            stopAndRemoveTimer(txId);
+            UserThread.execute(() -> callback.onTimeout(new TxBroadcastTimeoutException(tx, timeOut, wallet)));
+        }, timeOut);
+
+        broadcastTimerMap.put(txId, timeoutTimer);
 
         // We decided the least risky scenario is to commit the tx to the wallet and broadcast it later.
         // If it's a bsq tx WalletManager.publishAndCommitBsqTx() should have committed the tx to both bsq and btc

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/SellerProtocol.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/SellerProtocol.java
@@ -96,7 +96,13 @@ public abstract class SellerProtocol extends DisputeProtocol {
     }
 
     protected void handle(ShareBuyerPaymentAccountMessage message, NodeAddress peer) {
-        boolean publishDepositAfterValidation = !trade.isDepositPublished() && processModel.getDepositTx() != null;
+        // Only fiat publication is deferred until the buyer account is validated. A crypto deposit is already
+        // published by the delayed-payout task runner, so adding the publisher here would broadcast the same
+        // transaction a second time while the first broadcast is still pending.
+        boolean publishDepositAfterValidation = trade.getOffer() != null &&
+                trade.getOffer().isFiatOffer() &&
+                !trade.isDepositPublished() &&
+                processModel.getDepositTx() != null;
         expect(anyPhase(Trade.Phase.TAKER_FEE_PUBLISHED, Trade.Phase.DEPOSIT_PUBLISHED, Trade.Phase.DEPOSIT_CONFIRMED)
                 .with(message)
                 .from(peer))

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/model/ProcessModel.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/model/ProcessModel.java
@@ -67,6 +67,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -112,6 +113,12 @@ public class ProcessModel implements ProtocolModel<TradingPeer> {
     // finalizedDepositTx while fiat publication is deferred.
     @Nullable
     transient private Transaction depositTx;
+    // The seller can reach deposit publication from overlapping task runners, for instance from the startup
+    // recovery and from a stored buyer account reveal delivered shortly afterwards. The trade phase only advances
+    // in the broadcast callback, so it cannot express that a broadcast is pending. We keep publication
+    // single-flight until the callback ran. The flag is transient so a restart can retry publication.
+    @Getter(AccessLevel.NONE)
+    transient private boolean depositTxBroadcastPending;
 
     // Persistable Immutable
     private final String offerId;
@@ -316,6 +323,19 @@ public class ProcessModel implements ProtocolModel<TradingPeer> {
     public void setFinalizedDepositTx(Transaction depositTx) {
         this.depositTx = depositTx;
         finalizedDepositTx = depositTx.bitcoinSerialize();
+    }
+
+    public synchronized boolean tryStartDepositTxBroadcast() {
+        if (depositTxBroadcastPending) {
+            return false;
+        }
+
+        depositTxBroadcastPending = true;
+        return true;
+    }
+
+    public synchronized void finishDepositTxBroadcast() {
+        depositTxBroadcastPending = false;
     }
 
     @Nullable

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerPublishesDepositTx.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerPublishesDepositTx.java
@@ -56,40 +56,59 @@ public class SellerPublishesDepositTx extends TradeTask {
             }
 
             Transaction depositTx = checkCanonicalDepositTxFields(processModel.getDepositTx());
+            if (!processModel.tryStartDepositTxBroadcast()) {
+                log.info("A broadcast of the deposit tx is already pending, so we do not broadcast it again.");
+                complete();
+                return;
+            }
+
+            broadcastDepositTx(depositTx);
+        } catch (Throwable t) {
+            failed(t);
+        }
+    }
+
+    private void broadcastDepositTx(Transaction depositTx) {
+        try {
             processModel.getTradeWalletService().broadcastTx(depositTx,
                     new TxBroadcaster.Callback() {
                         @Override
                         public void onSuccess(Transaction transaction) {
-                            if (!completed) {
-                                // Now as we have published the deposit tx we set it in trade
-                                trade.applyDepositTx(depositTx);
-
-                                if (!trade.isDepositConfirmed()) {
-                                    trade.setState(Trade.State.SELLER_PUBLISHED_DEPOSIT_TX);
-                                }
-
-                                processModel.getBtcWalletService().swapTradeEntryToAvailableEntry(processModel.getOffer().getId(),
-                                        AddressEntry.Context.RESERVED_FOR_TRADE);
-
-                                processModel.getTradeManager().requestPersistence();
-
-                                complete();
-                            } else {
+                            processModel.finishDepositTxBroadcast();
+                            if (completed) {
                                 log.warn("We got the onSuccess callback called after the timeout has been triggered a complete().");
+                                return;
                             }
+
+                            // Now as we have published the deposit tx we set it in trade
+                            trade.applyDepositTx(depositTx);
+
+                            if (!trade.isDepositConfirmed()) {
+                                trade.setState(Trade.State.SELLER_PUBLISHED_DEPOSIT_TX);
+                            }
+
+                            processModel.getBtcWalletService().swapTradeEntryToAvailableEntry(processModel.getOffer().getId(),
+                                    AddressEntry.Context.RESERVED_FOR_TRADE);
+
+                            processModel.getTradeManager().requestPersistence();
+
+                            complete();
                         }
 
                         @Override
                         public void onFailure(TxBroadcastException exception) {
-                            if (!completed) {
-                                failed(exception);
-                            } else {
+                            processModel.finishDepositTxBroadcast();
+                            if (completed) {
                                 log.warn("We got the onFailure callback called after the timeout has been triggered a complete().");
+                                return;
                             }
+
+                            failed(exception);
                         }
                     });
         } catch (Throwable t) {
-            failed(t);
+            processModel.finishDepositTxBroadcast();
+            throw t;
         }
     }
 }

--- a/core/src/test/java/bisq/core/btc/wallet/TxBroadcasterTest.java
+++ b/core/src/test/java/bisq/core/btc/wallet/TxBroadcasterTest.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.btc.wallet;
+
+import bisq.core.btc.exceptions.TxBroadcastException;
+import bisq.core.btc.nodes.LocalBitcoinNode;
+import bisq.core.btc.wallet.http.MemPoolSpaceTxBroadcaster;
+
+import org.bitcoinj.core.PeerGroup;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionBroadcast;
+import org.bitcoinj.params.MainNetParams;
+import org.bitcoinj.wallet.Wallet;
+
+import com.google.common.util.concurrent.SettableFuture;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TxBroadcasterTest {
+    private static final int TIMEOUT_NOT_REACHED_IN_TEST = 300;
+
+    @BeforeEach
+    void setUp() {
+        // Keeps the redundant broadcast to the mempool services out of the test.
+        LocalBitcoinNode localBitcoinNode = mock(LocalBitcoinNode.class);
+        when(localBitcoinNode.shouldBeUsed()).thenReturn(true);
+        MemPoolSpaceTxBroadcaster.init(null, null, localBitcoinNode, false, false);
+    }
+
+    @Test
+    void aSecondBroadcastOfTheSameTxDoesNotSuppressThePendingCallback() {
+        Transaction tx = new Transaction(MainNetParams.get());
+        Wallet wallet = mock(Wallet.class);
+        SettableFuture<Transaction> broadcastFuture = SettableFuture.create();
+        PeerGroup peerGroup = peerGroup(tx, broadcastFuture);
+        RecordingCallback firstCallback = new RecordingCallback();
+        RecordingCallback secondCallback = new RecordingCallback();
+
+        TxBroadcaster.broadcastTx(wallet, peerGroup, tx, firstCallback, TIMEOUT_NOT_REACHED_IN_TEST);
+        TxBroadcaster.broadcastTx(wallet, peerGroup, tx, secondCallback, TIMEOUT_NOT_REACHED_IN_TEST);
+
+        // The misuse is reported to the second caller only, and the transaction is neither committed nor
+        // broadcast a second time.
+        assertNotNull(secondCallback.failure.get());
+        assertNull(secondCallback.success.get());
+        assertNull(firstCallback.failure.get());
+        verify(wallet, times(1)).maybeCommitTx(tx);
+        verify(peerGroup, times(1)).broadcastTransaction(tx);
+
+        // The pending broadcast of the first caller is still able to complete.
+        broadcastFuture.set(tx);
+        assertSame(tx, firstCallback.success.get());
+        assertNull(firstCallback.failure.get());
+    }
+
+    private static PeerGroup peerGroup(Transaction tx, SettableFuture<Transaction> broadcastFuture) {
+        TransactionBroadcast broadcast = TransactionBroadcast.createMockBroadcast(tx, broadcastFuture);
+        PeerGroup peerGroup = mock(PeerGroup.class);
+        when(peerGroup.broadcastTransaction(tx)).thenReturn(broadcast);
+        return peerGroup;
+    }
+
+    private static class RecordingCallback implements TxBroadcaster.Callback {
+        private final AtomicReference<Transaction> success = new AtomicReference<>();
+        private final AtomicReference<TxBroadcastException> failure = new AtomicReference<>();
+
+        @Override
+        public void onSuccess(Transaction transaction) {
+            success.set(transaction);
+        }
+
+        @Override
+        public void onFailure(TxBroadcastException exception) {
+            failure.set(exception);
+        }
+    }
+}

--- a/core/src/test/java/bisq/core/btc/wallet/TxBroadcasterTest.java
+++ b/core/src/test/java/bisq/core/btc/wallet/TxBroadcasterTest.java
@@ -21,6 +21,10 @@ import bisq.core.btc.exceptions.TxBroadcastException;
 import bisq.core.btc.nodes.LocalBitcoinNode;
 import bisq.core.btc.wallet.http.MemPoolSpaceTxBroadcaster;
 
+import bisq.common.FrameRateTimer;
+import bisq.common.Timer;
+import bisq.common.UserThread;
+
 import org.bitcoinj.core.PeerGroup;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionBroadcast;
@@ -29,14 +33,18 @@ import org.bitcoinj.wallet.Wallet;
 
 import com.google.common.util.concurrent.SettableFuture;
 
+import java.time.Duration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -47,10 +55,18 @@ class TxBroadcasterTest {
 
     @BeforeEach
     void setUp() {
+        ManualTimer.clear();
+        UserThread.setTimerClass(ManualTimer.class);
         // Keeps the redundant broadcast to the mempool services out of the test.
         LocalBitcoinNode localBitcoinNode = mock(LocalBitcoinNode.class);
         when(localBitcoinNode.shouldBeUsed()).thenReturn(true);
         MemPoolSpaceTxBroadcaster.init(null, null, localBitcoinNode, false, false);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ManualTimer.firePendingTimers();
+        UserThread.setTimerClass(FrameRateTimer.class);
     }
 
     @Test
@@ -79,6 +95,102 @@ class TxBroadcasterTest {
         assertNull(firstCallback.failure.get());
     }
 
+    @Test
+    void aLateResultFromAnExpiredBroadcastDoesNotConsumeANewerRequest() {
+        Transaction tx = new Transaction(MainNetParams.get());
+        Wallet wallet = mock(Wallet.class);
+        SettableFuture<Transaction> firstFuture = SettableFuture.create();
+        SettableFuture<Transaction> secondFuture = SettableFuture.create();
+        TransactionBroadcast firstBroadcast = TransactionBroadcast.createMockBroadcast(tx, firstFuture);
+        TransactionBroadcast secondBroadcast = TransactionBroadcast.createMockBroadcast(tx, secondFuture);
+        PeerGroup peerGroup = mock(PeerGroup.class);
+        when(peerGroup.broadcastTransaction(tx)).thenReturn(firstBroadcast, secondBroadcast);
+        RecordingCallback firstCallback = new RecordingCallback();
+        RecordingCallback secondCallback = new RecordingCallback();
+
+        TxBroadcaster.broadcastTx(wallet, peerGroup, tx, firstCallback, TIMEOUT_NOT_REACHED_IN_TEST);
+        ManualTimer firstTimer = ManualTimer.latest();
+        firstTimer.fire();
+        assertSame(tx, firstCallback.success.get());
+        assertEquals(1, firstCallback.successCount.get());
+
+        TxBroadcaster.broadcastTx(wallet, peerGroup, tx, secondCallback, TIMEOUT_NOT_REACHED_IN_TEST);
+        ManualTimer secondTimer = ManualTimer.latest();
+        firstFuture.set(tx);
+
+        assertFalse(secondTimer.stopped);
+        assertNull(secondCallback.success.get());
+        assertNull(secondCallback.failure.get());
+        assertEquals(1, firstCallback.successCount.get());
+
+        secondFuture.set(tx);
+
+        assertTrue(secondTimer.stopped);
+        assertSame(tx, secondCallback.success.get());
+        assertEquals(1, secondCallback.successCount.get());
+        assertNull(secondCallback.failure.get());
+    }
+
+    @Test
+    void aSynchronousWalletCommitFailureRemovesThePendingRequest() {
+        Transaction tx = new Transaction(MainNetParams.get());
+        Wallet wallet = mock(Wallet.class);
+        IllegalStateException setupFailure = new IllegalStateException("commit failed");
+        when(wallet.maybeCommitTx(tx)).thenThrow(setupFailure);
+        RecordingCallback callback = new RecordingCallback();
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                () -> TxBroadcaster.broadcastTx(wallet,
+                        mock(PeerGroup.class),
+                        tx,
+                        callback,
+                        TIMEOUT_NOT_REACHED_IN_TEST));
+
+        assertSame(setupFailure, thrown);
+        assertSynchronousFailureWasCleanedUp(tx, callback);
+    }
+
+    @Test
+    void aSynchronousPeerGroupFailureRemovesThePendingRequest() {
+        Transaction tx = new Transaction(MainNetParams.get());
+        Wallet wallet = mock(Wallet.class);
+        PeerGroup peerGroup = mock(PeerGroup.class);
+        IllegalStateException setupFailure = new IllegalStateException("broadcast failed");
+        when(peerGroup.broadcastTransaction(tx)).thenThrow(setupFailure);
+        RecordingCallback callback = new RecordingCallback();
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                () -> TxBroadcaster.broadcastTx(wallet,
+                        peerGroup,
+                        tx,
+                        callback,
+                        TIMEOUT_NOT_REACHED_IN_TEST));
+
+        assertSame(setupFailure, thrown);
+        assertSynchronousFailureWasCleanedUp(tx, callback);
+    }
+
+    private static void assertSynchronousFailureWasCleanedUp(Transaction tx, RecordingCallback failedCallback) {
+        ManualTimer failedTimer = ManualTimer.latest();
+        assertTrue(failedTimer.stopped);
+        failedTimer.fire();
+        assertEquals(0, failedCallback.successCount.get());
+        assertEquals(0, failedCallback.failureCount.get());
+
+        Wallet retryWallet = mock(Wallet.class);
+        SettableFuture<Transaction> retryFuture = SettableFuture.create();
+        RecordingCallback retryCallback = new RecordingCallback();
+        TxBroadcaster.broadcastTx(retryWallet,
+                peerGroup(tx, retryFuture),
+                tx,
+                retryCallback,
+                TIMEOUT_NOT_REACHED_IN_TEST);
+        retryFuture.set(tx);
+
+        assertSame(tx, retryCallback.success.get());
+        assertNull(retryCallback.failure.get());
+    }
+
     private static PeerGroup peerGroup(Transaction tx, SettableFuture<Transaction> broadcastFuture) {
         TransactionBroadcast broadcast = TransactionBroadcast.createMockBroadcast(tx, broadcastFuture);
         PeerGroup peerGroup = mock(PeerGroup.class);
@@ -89,15 +201,65 @@ class TxBroadcasterTest {
     private static class RecordingCallback implements TxBroadcaster.Callback {
         private final AtomicReference<Transaction> success = new AtomicReference<>();
         private final AtomicReference<TxBroadcastException> failure = new AtomicReference<>();
+        private final AtomicInteger successCount = new AtomicInteger();
+        private final AtomicInteger failureCount = new AtomicInteger();
 
         @Override
         public void onSuccess(Transaction transaction) {
             success.set(transaction);
+            successCount.incrementAndGet();
         }
 
         @Override
         public void onFailure(TxBroadcastException exception) {
             failure.set(exception);
+            failureCount.incrementAndGet();
+        }
+    }
+
+    public static class ManualTimer implements Timer {
+        private static final List<ManualTimer> timers = new ArrayList<>();
+
+        private Runnable action;
+        private boolean stopped;
+
+        public ManualTimer() {
+            timers.add(this);
+        }
+
+        @Override
+        public Timer runLater(Duration delay, Runnable action) {
+            this.action = action;
+            return this;
+        }
+
+        @Override
+        public Timer runPeriodically(Duration interval, Runnable action) {
+            this.action = action;
+            return this;
+        }
+
+        @Override
+        public void stop() {
+            stopped = true;
+        }
+
+        private void fire() {
+            if (!stopped) {
+                action.run();
+            }
+        }
+
+        private static ManualTimer latest() {
+            return timers.get(timers.size() - 1);
+        }
+
+        private static void firePendingTimers() {
+            List.copyOf(timers).forEach(ManualTimer::fire);
+        }
+
+        private static void clear() {
+            timers.clear();
         }
     }
 }

--- a/core/src/test/java/bisq/core/trade/protocol/bisq_v1/SellerProtocolMessageHandlingTest.java
+++ b/core/src/test/java/bisq/core/trade/protocol/bisq_v1/SellerProtocolMessageHandlingTest.java
@@ -17,21 +17,32 @@
 
 package bisq.core.trade.protocol.bisq_v1;
 
+import bisq.core.offer.Offer;
+import bisq.core.trade.model.TradeModel;
 import bisq.core.trade.model.bisq_v1.SellerAsMakerTrade;
 import bisq.core.trade.model.bisq_v1.Trade;
+import bisq.core.trade.protocol.FluentProtocol;
 import bisq.core.trade.protocol.TradeMessage;
 import bisq.core.trade.protocol.bisq_v1.messages.CounterCurrencyTransferStartedMessage;
 import bisq.core.trade.protocol.bisq_v1.messages.ShareBuyerPaymentAccountMessage;
 import bisq.core.trade.protocol.bisq_v1.model.ProcessModel;
+import bisq.core.trade.protocol.bisq_v1.tasks.ApplyFilter;
 import bisq.core.trade.protocol.bisq_v1.tasks.TradeTask;
+import bisq.core.trade.protocol.bisq_v1.tasks.VerifyPeersAccountAgeWitness;
+import bisq.core.trade.protocol.bisq_v1.tasks.seller.SellerProcessShareBuyerPaymentAccountMessage;
+import bisq.core.trade.protocol.bisq_v1.tasks.seller.SellerPublishesDepositTx;
+import bisq.core.trade.protocol.bisq_v1.tasks.seller.SellerPublishesTradeStatistics;
 import bisq.core.trade.protocol.bisq_v1.tasks.seller.SellerVerifyBuyerPaymentAccount;
 
 import bisq.network.p2p.NodeAddress;
+
+import bisq.common.taskrunner.Task;
 
 import org.bitcoinj.core.Transaction;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -51,6 +62,42 @@ class SellerProtocolMessageHandlingTest {
 
         assertSame(message, setup.protocol.revealMessage);
         assertSame(peer, setup.protocol.revealPeer);
+    }
+
+    @Test
+    void cryptoBuyerAccountRevealDoesNotScheduleAnotherDepositPublication() {
+        TestSetup setup = new TestSetup();
+        Offer offer = mock(Offer.class);
+        when(offer.isFiatOffer()).thenReturn(false);
+        when(setup.trade.getOffer()).thenReturn(offer);
+        when(setup.processModel.getDepositTx()).thenReturn(mock(Transaction.class));
+        setup.protocol.recordTaskSelection = true;
+
+        setup.protocol.handleBuyerPaymentAccountReveal(mock(ShareBuyerPaymentAccountMessage.class), mock(NodeAddress.class));
+
+        assertArrayEquals(new Class[]{SellerProcessShareBuyerPaymentAccountMessage.class,
+                        ApplyFilter.class,
+                        VerifyPeersAccountAgeWitness.class},
+                setup.protocol.selectedTasks);
+    }
+
+    @Test
+    void fiatBuyerAccountRevealSchedulesPendingDepositPublication() {
+        TestSetup setup = new TestSetup();
+        Offer offer = mock(Offer.class);
+        when(offer.isFiatOffer()).thenReturn(true);
+        when(setup.trade.getOffer()).thenReturn(offer);
+        when(setup.processModel.getDepositTx()).thenReturn(mock(Transaction.class));
+        setup.protocol.recordTaskSelection = true;
+
+        setup.protocol.handleBuyerPaymentAccountReveal(mock(ShareBuyerPaymentAccountMessage.class), mock(NodeAddress.class));
+
+        assertArrayEquals(new Class[]{SellerProcessShareBuyerPaymentAccountMessage.class,
+                        ApplyFilter.class,
+                        VerifyPeersAccountAgeWitness.class,
+                        SellerPublishesDepositTx.class,
+                        SellerPublishesTradeStatistics.class},
+                setup.protocol.selectedTasks);
     }
 
     @Test
@@ -88,6 +135,8 @@ class SellerProtocolMessageHandlingTest {
         private boolean ackSent;
         private boolean ackResult;
         private boolean mailboxMessageRemoved;
+        private boolean recordTaskSelection;
+        private Class<? extends Task<TradeModel>>[] selectedTasks;
 
         private TestSellerProtocol(SellerAsMakerTrade trade) {
             super(trade);
@@ -97,6 +146,34 @@ class SellerProtocolMessageHandlingTest {
         protected void handle(ShareBuyerPaymentAccountMessage message, NodeAddress peer) {
             revealMessage = message;
             revealPeer = peer;
+        }
+
+        private void handleBuyerPaymentAccountReveal(ShareBuyerPaymentAccountMessage message, NodeAddress peer) {
+            super.handle(message, peer);
+        }
+
+        @Override
+        protected FluentProtocol expect(FluentProtocol.Condition condition) {
+            if (!recordTaskSelection) {
+                return super.expect(condition);
+            }
+            return new FluentProtocol(this) {
+                @Override
+                public FluentProtocol setup(Setup setup) {
+                    selectedTasks = setup.getTasks();
+                    return this;
+                }
+
+                @Override
+                public FluentProtocol run(Runnable runnable) {
+                    return this;
+                }
+
+                @Override
+                public FluentProtocol executeTasks() {
+                    return this;
+                }
+            };
         }
 
         @Override

--- a/core/src/test/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerPublishesDepositTxTest.java
+++ b/core/src/test/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerPublishesDepositTxTest.java
@@ -17,6 +17,7 @@
 
 package bisq.core.trade.protocol.bisq_v1.tasks.seller;
 
+import bisq.core.btc.exceptions.TxBroadcastException;
 import bisq.core.btc.wallet.TradeWalletService;
 import bisq.core.btc.wallet.TxBroadcaster;
 import bisq.core.offer.Offer;
@@ -25,6 +26,9 @@ import bisq.core.trade.model.TradeModel;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.model.ProcessModel;
 
+import bisq.common.crypto.Encryption;
+import bisq.common.crypto.PubKeyRing;
+import bisq.common.crypto.Sig;
 import bisq.common.taskrunner.TaskRunner;
 
 import org.bitcoinj.core.Transaction;
@@ -34,14 +38,17 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -81,12 +88,61 @@ class SellerPublishesDepositTxTest {
         verify(tradeWalletService).broadcastTx(same(depositTx), any(TxBroadcaster.Callback.class));
     }
 
+    @Test
+    void anOverlappingTaskRunnerDoesNotBroadcastTheDepositASecondTime() {
+        ProcessModel processModel = processModel(true, true);
+        Transaction depositTx = new Transaction(MainNetParams.get());
+        TradeWalletService tradeWalletService = mock(TradeWalletService.class);
+        when(processModel.getDepositTx()).thenReturn(depositTx);
+        when(processModel.getTradeWalletService()).thenReturn(tradeWalletService);
+        Trade trade = trade(processModel);
+
+        // The callback of the first broadcast stays pending, so the trade phase does not advance yet.
+        runTask(trade);
+        TaskResult result = runTask(trade);
+
+        assertTrue(result.completed());
+        assertNull(result.errorMessage());
+        verify(tradeWalletService, times(1)).broadcastTx(same(depositTx), any(TxBroadcaster.Callback.class));
+    }
+
+    @Test
+    void aFailedBroadcastReleasesTheGuardSoPublicationCanBeRetried() {
+        ProcessModel processModel = processModel(true, true);
+        Transaction depositTx = new Transaction(MainNetParams.get());
+        TradeWalletService tradeWalletService = mock(TradeWalletService.class);
+        when(processModel.getDepositTx()).thenReturn(depositTx);
+        when(processModel.getTradeWalletService()).thenReturn(tradeWalletService);
+        Trade trade = trade(processModel);
+
+        runTask(trade);
+        ArgumentCaptor<TxBroadcaster.Callback> callback = ArgumentCaptor.forClass(TxBroadcaster.Callback.class);
+        verify(tradeWalletService).broadcastTx(same(depositTx), callback.capture());
+        callback.getValue().onFailure(new TxBroadcastException("broadcast failed"));
+
+        runTask(trade);
+
+        verify(tradeWalletService, times(2)).broadcastTx(same(depositTx), any(TxBroadcaster.Callback.class));
+    }
+
     private static ProcessModel processModel(boolean accountValidated, boolean messageDelivered) {
         ProcessModel processModel = mock(ProcessModel.class);
         when(processModel.isBuyerPaymentAccountValidated()).thenReturn(accountValidated);
         when(processModel.isDepositTxAndDelayedPayoutTxMessageDelivered()).thenReturn(messageDelivered);
         when(processModel.getTradeManager()).thenReturn(mock(TradeManager.class));
+        // The single-flight guard is trade state, so we delegate it to a real ProcessModel instead of
+        // reimplementing it in the test.
+        ProcessModel guard = new ProcessModel("offer-id", "account-id", pubKeyRing());
+        when(processModel.tryStartDepositTxBroadcast()).thenAnswer(invocation -> guard.tryStartDepositTxBroadcast());
+        doAnswer(invocation -> {
+            guard.finishDepositTxBroadcast();
+            return null;
+        }).when(processModel).finishDepositTxBroadcast();
         return processModel;
+    }
+
+    private static PubKeyRing pubKeyRing() {
+        return new PubKeyRing(Sig.generateKeyPair().getPublic(), Encryption.generateKeyPair().getPublic());
     }
 
     private static Trade trade(ProcessModel processModel) {

--- a/core/src/test/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerPublishesDepositTxTest.java
+++ b/core/src/test/java/bisq/core/trade/protocol/bisq_v1/tasks/seller/SellerPublishesDepositTxTest.java
@@ -18,6 +18,7 @@
 package bisq.core.trade.protocol.bisq_v1.tasks.seller;
 
 import bisq.core.btc.exceptions.TxBroadcastException;
+import bisq.core.btc.wallet.BtcWalletService;
 import bisq.core.btc.wallet.TradeWalletService;
 import bisq.core.btc.wallet.TxBroadcaster;
 import bisq.core.offer.Offer;
@@ -89,21 +90,33 @@ class SellerPublishesDepositTxTest {
     }
 
     @Test
-    void anOverlappingTaskRunnerDoesNotBroadcastTheDepositASecondTime() {
+    void anOverlappingCryptoTaskRunnerDoesNotBroadcastTheDepositASecondTime() {
         ProcessModel processModel = processModel(true, true);
         Transaction depositTx = new Transaction(MainNetParams.get());
         TradeWalletService tradeWalletService = mock(TradeWalletService.class);
         when(processModel.getDepositTx()).thenReturn(depositTx);
         when(processModel.getTradeWalletService()).thenReturn(tradeWalletService);
-        Trade trade = trade(processModel);
+        when(processModel.getBtcWalletService()).thenReturn(mock(BtcWalletService.class));
+        Trade trade = trade(processModel, false);
 
         // The callback of the first broadcast stays pending, so the trade phase does not advance yet.
-        runTask(trade);
-        TaskResult result = runTask(trade);
+        TaskResult firstResult = runTask(trade);
+        TaskResult overlappingResult = runTask(trade);
 
-        assertTrue(result.completed());
-        assertNull(result.errorMessage());
-        verify(tradeWalletService, times(1)).broadcastTx(same(depositTx), any(TxBroadcaster.Callback.class));
+        assertTrue(overlappingResult.completed());
+        assertNull(overlappingResult.errorMessage());
+        ArgumentCaptor<TxBroadcaster.Callback> callback = ArgumentCaptor.forClass(TxBroadcaster.Callback.class);
+        verify(tradeWalletService).broadcastTx(same(depositTx), callback.capture());
+
+        callback.getValue().onSuccess(depositTx);
+
+        assertTrue(firstResult.completed());
+        verify(trade).applyDepositTx(same(depositTx));
+
+        // The callback releases the guard. The mock deliberately keeps the persisted phase unpublished so a third
+        // task proves that publication can be retried after the in-flight operation ended.
+        runTask(trade);
+        verify(tradeWalletService, times(2)).broadcastTx(same(depositTx), any(TxBroadcaster.Callback.class));
     }
 
     @Test
@@ -146,8 +159,14 @@ class SellerPublishesDepositTxTest {
     }
 
     private static Trade trade(ProcessModel processModel) {
+        return trade(processModel, true);
+    }
+
+    private static Trade trade(ProcessModel processModel, boolean isFiatOffer) {
         Offer offer = mock(Offer.class);
-        when(offer.isFiatOffer()).thenReturn(true);
+        when(offer.isFiatOffer()).thenReturn(isFiatOffer);
+        when(offer.getId()).thenReturn("offer-id");
+        when(processModel.getOffer()).thenReturn(offer);
         Trade trade = mock(Trade.class);
         when(trade.getOffer()).thenReturn(offer);
         when(trade.getProcessModel()).thenReturn(processModel);
@@ -164,9 +183,16 @@ class SellerPublishesDepositTxTest {
                 errorMessage::set);
         taskRunner.addTasks(SellerPublishesDepositTx.class);
         taskRunner.run();
-        return new TaskResult(completed.get(), errorMessage.get());
+        return new TaskResult(completed, errorMessage);
     }
 
-    private record TaskResult(boolean completed, String errorMessage) {
+    private record TaskResult(AtomicBoolean completedState, AtomicReference<String> errorMessageState) {
+        private boolean completed() {
+            return completedState.get();
+        }
+
+        private String errorMessage() {
+            return errorMessageState.get();
+        }
     }
 }

--- a/docs/specifications/trade/fiat-buyer-payment-account-validation.md
+++ b/docs/specifications/trade/fiat-buyer-payment-account-validation.md
@@ -45,6 +45,17 @@ The prerequisites may complete in either order. Completing either one must re-ev
 publication, but publication must remain blocked until both are persisted as complete. Repeated
 messages and retries must not cause a second logical publication.
 
+Deferred publication belongs to fiat trades only. A crypto deposit is published as soon as the
+delayed-payout signature has been processed, so a buyer account reveal must not trigger publication
+for a crypto trade.
+
+Publication is single-flight per trade. The persisted trade phase advances only when the wallet
+reports the broadcast result, so it cannot express that a broadcast is still pending. A second
+publication attempt that starts before that result arrived must complete without broadcasting again,
+and the first attempt stays responsible for recording the transaction on the trade. Requesting a
+second broadcast of a transaction that is already being broadcast must never disturb the pending
+broadcast; otherwise the transaction can reach the blockchain while the trade keeps no record of it.
+
 The seller must persist the finalized deposit transaction before publication can be deferred. If the
 seller restarts while either prerequisite is still pending, it must restore the exact transaction,
 resume delivery of the deposit and delayed-payout transaction message when necessary, and


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate transaction broadcasts during overlapping operations.
  * Improved broadcast timeout, failure, and retry handling.
  * Ensured stale completion events do not trigger incorrect updates.
  * Limited deferred deposit publication to fiat trades; crypto trade flows remain unaffected.

* **Documentation**
  * Clarified single-flight deposit publication and pending transaction behavior for fiat trades.

* **Tests**
  * Added coverage for duplicate broadcasts, failures, retries, timeouts, and fiat versus crypto workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->