### PR TITLE
Add WAM Coin (WAM)

### DIFF
--- a/assets/src/main/java/bisq/asset/coins/WAMCoin.java
+++ b/assets/src/main/java/bisq/asset/coins/WAMCoin.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.BitcoinAddressValidator;
+import bisq.asset.Coin;
+import bisq.asset.NetworkParametersAdapter;
+
+public class WAMCoin extends Coin {
+    public WAMCoin() {
+        super("WAM Coin", "WAM", new BitcoinAddressValidator(new WAMCoinMainNetParams()), Network.MAINNET);
+    }
+
+    public static class WAMCoinMainNetParams extends NetworkParametersAdapter {
+        public WAMCoinMainNetParams() {
+            this.addressHeader = 73;         // 'W'
+            this.p2shHeader = 135;           // 'w'
+            this.segwitAddressHrp = "wam";
+        }
+    }
+}

--- a/assets/src/main/resources/META-INF/services/bisq.asset.Asset
+++ b/assets/src/main/resources/META-INF/services/bisq.asset.Asset
@@ -112,6 +112,7 @@ bisq.asset.coins.uPlexa
 bisq.asset.coins.VARIUS
 bisq.asset.coins.Veil
 bisq.asset.coins.Vertcoin
+bisq.asset.coins.WAMCoin
 bisq.asset.coins.Webchain
 bisq.asset.coins.WORX
 bisq.asset.coins.WrkzCoin

--- a/assets/src/test/java/bisq/asset/coins/WAMCoinTest.java
+++ b/assets/src/test/java/bisq/asset/coins/WAMCoinTest.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.asset.coins;
+
+import bisq.asset.AbstractAssetTest;
+
+import org.junit.jupiter.api.Test;
+
+public class WAMCoinTest extends AbstractAssetTest {
+
+    public WAMCoinTest() {
+        super(new WAMCoin());
+    }
+
+    // Every address below was produced or judged by wamd itself on WAM
+    // mainnet, not written by hand: the valid ones come from getnewaddress,
+    // and validateaddress rejects each of the invalid ones.
+
+    @Test
+    public void testValidAddresses() {
+        // P2PKH, version byte 73
+        assertValidAddress("Wif4JEpEgvgZnneibRBDodYUe1We3ft1j4");
+        assertValidAddress("WWWEvpC98mfzjRMZHtaRaucMjopqH2viQz");
+        assertValidAddress("WNg2svm2qApxheBKndKGQ9sRwporvRgRpT");
+        // P2SH, version byte 135
+        assertValidAddress("wM6b6wkri2n9Ni2KyNC6ftHjfBf6iXoP1n");
+        // P2WPKH, hrp "wam"
+        assertValidAddress("wam1q85enqu8zptx20fzrdr07p5vt5ffx9udnvgv366");
+        assertValidAddress("wam1q4vgyrjdjk742nk5cdztp9fj72g2hspjzm6gf0f");
+        assertValidAddress("wam1qv8amdskgpwg5whapwgdaafe5t7xhs7q5aqkhvq");
+    }
+
+    @Test
+    public void testInvalidAddresses() {
+        // Bitcoin, whose version byte is not ours
+        assertInvalidAddress("1LgfapHEPhZbRF9pMd5WPT35hFXcZS1USrW");
+        assertInvalidAddress("bc1qxtm55gultqzhqzl2p3ks50hg2478y3hehuj6dz");
+        // WAM testnet, which must not be accepted as mainnet
+        assertInvalidAddress("twam1q8fwe4ucywdzf2p80zqhpucwj8dy9kgk4x4s40m");
+        // A valid address with its last character changed: the checksum fails
+        assertInvalidAddress("WWWEvpC98mfzjRMZHtaRaucMjopqH2viQx");
+        // Right prefix, one character short
+        assertInvalidAddress("Wif4JEpEgvgZnneibRBDodYUe1We3ft1j");
+        assertInvalidAddress("Wif4JEpEgvgZnneibRBDodYUe1We3ft1j4#");
+        // The blank case is left to AbstractAssetTest, which already asserts it
+        // for every asset.
+    }
+}


### PR DESCRIPTION
WAM Coin is a Bitcoin Core v28.1 fork using RandomX proof of work. Address handling, the transaction format, the script language and SegWit are Bitcoin's, so this needs only the three constants BitcoinAddressValidator reads:

  addressHeader    73    'W'
  p2shHeader      135    'w'
  segwitAddressHrp  wam

Every address in the test came from the coin's own node rather than being written by hand: the valid ones from getnewaddress on mainnet, and each invalid one was handed to validateaddress and refused. They cover a Bitcoin address whose version byte differs, a bc1 address whose hrp differs, a testnet twam1 address that must not validate as mainnet, and a valid address with its last character changed so the checksum has to catch it.

Source:   https://github.com/wam-coin-official/wam-coin
Explorer: https://explorer.wamcoin.org

The chain has not launched yet; mainnet is scheduled for 2026-09-15. Happy to hold this open until then, or to answer anything about the listing terms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for WAM Coin.
  * Recognizes and validates WAM Coin mainnet addresses, including legacy, P2SH, and SegWit formats.

* **Tests**
  * Added coverage for valid WAM Coin address formats.
  * Added validation checks for invalid, testnet, malformed, truncated, and checksum-corrupted addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->