### PR TITLE
fix(bridge): register snapshot subscriber synchronously

### DIFF
--- a/bridge/src/main/java/bisq/bridge/grpc/services/BsqBlockGrpcService.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/services/BsqBlockGrpcService.java
@@ -125,6 +125,10 @@ public class BsqBlockGrpcService extends BsqBlockGrpcServiceGrpc.BsqBlockGrpcSer
                     .setBsqBlock(responseProto)
                     .build();
             snapshotObservers.forEach(observer -> {
+                // Deregistered between the capture and now, e.g. after its readiness event failed.
+                if (!snapshotStreamObservers.contains(observer)) {
+                    return;
+                }
                 try {
                     observer.onNext(snapshotStreamResponse);
                 } catch (Exception e) {
@@ -135,7 +139,9 @@ public class BsqBlockGrpcService extends BsqBlockGrpcServiceGrpc.BsqBlockGrpcSer
         } catch (Exception e) {
             log.error("Error at processing new bsqBlockDto", e);
             streamObservers.forEach(observer -> notifyOnError(observer, e));
-            snapshotObservers.forEach(observer -> notifyOnError(observer, e));
+            snapshotObservers.stream()
+                    .filter(snapshotStreamObservers::contains)
+                    .forEach(observer -> notifyOnError(observer, e));
         }
     }
 
@@ -160,17 +166,23 @@ public class BsqBlockGrpcService extends BsqBlockGrpcServiceGrpc.BsqBlockGrpcSer
             // stream and is also covered by the height, which is a duplicate rather than a gap. The event is sent
             // via notifyObserversExecutor so that it precedes any block queued after this registration.
             snapshotStreamObservers.add(managedStreamObserver);
-            int subscriptionReadyHeight = daoStateService.getChainHeight();
-            CompletableFuture.runAsync(() -> {
-                try {
-                    managedStreamObserver.onNext(bisq.bridge.protobuf.BsqBlockSubscriptionEvent.newBuilder()
-                            .setSubscriptionReadyHeight(subscriptionReadyHeight)
-                            .build());
-                } catch (Exception e) {
-                    log.error("Failed to establish snapshot stream observer", e);
-                    notifyOnError(managedStreamObserver, e);
-                }
-            }, notifyObserversExecutor);
+            try {
+                int subscriptionReadyHeight = daoStateService.getChainHeight();
+                CompletableFuture.runAsync(() -> {
+                    try {
+                        managedStreamObserver.onNext(bisq.bridge.protobuf.BsqBlockSubscriptionEvent.newBuilder()
+                                .setSubscriptionReadyHeight(subscriptionReadyHeight)
+                                .build());
+                    } catch (Exception e) {
+                        log.error("Failed to establish snapshot stream observer", e);
+                        notifyOnError(managedStreamObserver, e);
+                    }
+                }, notifyObserversExecutor);
+            } catch (Exception e) {
+                // Registered but never armed, so deregister it. notifyOnError does that via ManagedStreamObserver.
+                log.error("Failed to set up snapshot subscription", e);
+                notifyOnError(managedStreamObserver, e);
+            }
         }
     }
 

--- a/bridge/src/main/java/bisq/bridge/grpc/services/BsqBlockGrpcService.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/services/BsqBlockGrpcService.java
@@ -329,12 +329,17 @@ public class BsqBlockGrpcService extends BsqBlockGrpcServiceGrpc.BsqBlockGrpcSer
         }
     }
 
+    // Best effort: signalling one observer must not prevent signalling the remaining ones.
     private void notifyOnError(StreamObserver<?> observer,
                                Exception exception) {
-        observer.onError(Status.INTERNAL
-                .withDescription("Error processing bsqBlock data")
-                .withCause(exception)
-                .asRuntimeException());
+        try {
+            observer.onError(Status.INTERNAL
+                    .withDescription("Error processing bsqBlock data")
+                    .withCause(exception)
+                    .asRuntimeException());
+        } catch (Exception e) {
+            log.warn("Failed to signal error to observer {}", observer, e);
+        }
     }
 
 }

--- a/bridge/src/main/java/bisq/bridge/grpc/services/BsqBlockGrpcService.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/services/BsqBlockGrpcService.java
@@ -69,6 +69,10 @@ public class BsqBlockGrpcService extends BsqBlockGrpcServiceGrpc.BsqBlockGrpcSer
     private final Set<ManagedStreamObserver<bisq.bridge.protobuf.BsqBlockDto>> streamObservers = new CopyOnWriteArraySet<>();
     private final Set<ManagedStreamObserver<bisq.bridge.protobuf.BsqBlockSubscriptionEvent>> snapshotStreamObservers =
             new CopyOnWriteArraySet<>();
+    // Serializes snapshot subscription setup against block publication, so that registering an observer and
+    // queueing its subscriptionReadyHeight event cannot be interleaved with capturing observers and queueing a
+    // block event. Without that, a block captured between the two would reach the executor first.
+    private final Object snapshotSubscriptionLock = new Object();
 
     @Inject
     public BsqBlockGrpcService(DaoStateService daoStateService,
@@ -85,43 +89,54 @@ public class BsqBlockGrpcService extends BsqBlockGrpcServiceGrpc.BsqBlockGrpcSer
     @Override
     public void onParseBlockCompleteAfterBatchProcessing(Block block) {
         log.info("onParseBlockCompleteAfterBatchProcessing");
-        if (streamObservers.isEmpty() && snapshotStreamObservers.isEmpty()) {
-            return;
-        }
-
-        CompletableFuture.runAsync(() -> {
-            try {
-                Map<String, BondedReputation> bondedReputationByLockupTxId = getBondedReputationByLockupTxId();
-                Map<String, BondedReputation> bondedReputationByUnlockTxId = getBondedReputationByUnlockTxId();
-                BsqBlockDto bsqBlockDto = toBlockDto(block, bondedReputationByLockupTxId, bondedReputationByUnlockTxId);
-                // Empty live blocks provide the clock for bonded-role revalidation. Historical requests stay sparse.
-                log.info("Notify observers of new bsqBlockDto: {}", bsqBlockDto);
-                var responseProto = bsqBlockDto.toProtoMessage();
-                streamObservers.forEach(observer -> {
-                    try {
-                        observer.onNext(responseProto);
-                    } catch (Exception e) {
-                        log.error("Failed to notify observer", e);
-                        notifyOnError(observer, e);
-                    }
-                });
-                var snapshotStreamResponse = bisq.bridge.protobuf.BsqBlockSubscriptionEvent.newBuilder()
-                        .setBsqBlock(responseProto)
-                        .build();
-                snapshotStreamObservers.forEach(observer -> {
-                    try {
-                        observer.onNext(snapshotStreamResponse);
-                    } catch (Exception e) {
-                        log.error("Failed to notify snapshot observer", e);
-                        notifyOnError(observer, e);
-                    }
-                });
-            } catch (Exception e) {
-                log.error("Error at processing new bsqBlockDto", e);
-                streamObservers.forEach(observer -> notifyOnError(observer, e));
-                snapshotStreamObservers.forEach(observer -> notifyOnError(observer, e));
+        synchronized (snapshotSubscriptionLock) {
+            // A snapshot observer visible here already has its subscriptionReadyHeight queued, so the single
+            // threaded notifyObserversExecutor delivers that event before this block. A client subscribing later
+            // is absent from the capture and backfills via requestBsqBlocks, as the height it receives already
+            // covers this block. Plain subscribers have no such handshake and no backfill signal, so they are
+            // notified from the live set at delivery time rather than risk dropping a block.
+            List<ManagedStreamObserver<bisq.bridge.protobuf.BsqBlockSubscriptionEvent>> snapshotObservers =
+                    List.copyOf(snapshotStreamObservers);
+            if (streamObservers.isEmpty() && snapshotObservers.isEmpty()) {
+                return;
             }
-        }, notifyObserversExecutor);
+            CompletableFuture.runAsync(() -> publishBlock(block, snapshotObservers), notifyObserversExecutor);
+        }
+    }
+
+    private void publishBlock(Block block,
+                              List<ManagedStreamObserver<bisq.bridge.protobuf.BsqBlockSubscriptionEvent>> snapshotObservers) {
+        try {
+            Map<String, BondedReputation> bondedReputationByLockupTxId = getBondedReputationByLockupTxId();
+            Map<String, BondedReputation> bondedReputationByUnlockTxId = getBondedReputationByUnlockTxId();
+            BsqBlockDto bsqBlockDto = toBlockDto(block, bondedReputationByLockupTxId, bondedReputationByUnlockTxId);
+            // Empty live blocks provide the clock for bonded-role revalidation. Historical requests stay sparse.
+            log.info("Notify observers of new bsqBlockDto: {}", bsqBlockDto);
+            var responseProto = bsqBlockDto.toProtoMessage();
+            streamObservers.forEach(observer -> {
+                try {
+                    observer.onNext(responseProto);
+                } catch (Exception e) {
+                    log.error("Failed to notify observer", e);
+                    notifyOnError(observer, e);
+                }
+            });
+            var snapshotStreamResponse = bisq.bridge.protobuf.BsqBlockSubscriptionEvent.newBuilder()
+                    .setBsqBlock(responseProto)
+                    .build();
+            snapshotObservers.forEach(observer -> {
+                try {
+                    observer.onNext(snapshotStreamResponse);
+                } catch (Exception e) {
+                    log.error("Failed to notify snapshot observer", e);
+                    notifyOnError(observer, e);
+                }
+            });
+        } catch (Exception e) {
+            log.error("Error at processing new bsqBlockDto", e);
+            streamObservers.forEach(observer -> notifyOnError(observer, e));
+            snapshotObservers.forEach(observer -> notifyOnError(observer, e));
+        }
     }
 
 
@@ -140,17 +155,23 @@ public class BsqBlockGrpcService extends BsqBlockGrpcServiceGrpc.BsqBlockGrpcSer
         var managedStreamObserver = new ManagedStreamObserver<>(streamObserver,
                 snapshotStreamObservers::remove,
                 snapshotStreamObservers::remove);
-        CompletableFuture.runAsync(() -> {
-            try {
-                snapshotStreamObservers.add(managedStreamObserver);
-                managedStreamObserver.onNext(bisq.bridge.protobuf.BsqBlockSubscriptionEvent.newBuilder()
-                        .setSubscriptionReadyHeight(daoStateService.getChainHeight())
-                        .build());
-            } catch (Exception e) {
-                log.error("Failed to establish snapshot stream observer", e);
-                notifyOnError(managedStreamObserver, e);
-            }
-        }, notifyObserversExecutor);
+        synchronized (snapshotSubscriptionLock) {
+            // We register before reading the chain height so that a block parsed in between is delivered on the
+            // stream and is also covered by the height, which is a duplicate rather than a gap. The event is sent
+            // via notifyObserversExecutor so that it precedes any block queued after this registration.
+            snapshotStreamObservers.add(managedStreamObserver);
+            int subscriptionReadyHeight = daoStateService.getChainHeight();
+            CompletableFuture.runAsync(() -> {
+                try {
+                    managedStreamObserver.onNext(bisq.bridge.protobuf.BsqBlockSubscriptionEvent.newBuilder()
+                            .setSubscriptionReadyHeight(subscriptionReadyHeight)
+                            .build());
+                } catch (Exception e) {
+                    log.error("Failed to establish snapshot stream observer", e);
+                    notifyOnError(managedStreamObserver, e);
+                }
+            }, notifyObserversExecutor);
+        }
     }
 
     @Override

--- a/bridge/src/main/java/bisq/bridge/grpc/services/BurningmanGrpcService.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/services/BurningmanGrpcService.java
@@ -208,11 +208,16 @@ public class BurningmanGrpcService extends BurningmanGrpcServiceGrpc.BurningmanG
         }
     }
 
+    // Best effort: signalling one observer must not prevent signalling the remaining ones.
     private void notifyOnError(StreamObserver<?> observer,
                                Exception exception) {
-        observer.onError(Status.INTERNAL
-                .withDescription("Error processing burningman data")
-                .withCause(exception)
-                .asRuntimeException());
+        try {
+            observer.onError(Status.INTERNAL
+                    .withDescription("Error processing burningman data")
+                    .withCause(exception)
+                    .asRuntimeException());
+        } catch (Exception e) {
+            log.warn("Failed to signal error to observer {}", observer, e);
+        }
     }
 }

--- a/bridge/src/main/java/bisq/bridge/grpc/services/ManagedStreamObserver.java
+++ b/bridge/src/main/java/bisq/bridge/grpc/services/ManagedStreamObserver.java
@@ -48,8 +48,12 @@ public class ManagedStreamObserver<T> implements StreamObserver<T> {
 
     @Override
     public void onError(Throwable throwable) {
-        delegate.onError(throwable);
-        onErrorCallback.accept(this);
+        // An already closed stream rejects onError, so we deregister in a finally to not leak a dead observer.
+        try {
+            delegate.onError(throwable);
+        } finally {
+            onErrorCallback.accept(this);
+        }
     }
 
     @Override

--- a/bridge/src/test/java/bisq/bridge/grpc/services/BsqBlockGrpcServiceTest.java
+++ b/bridge/src/test/java/bisq/bridge/grpc/services/BsqBlockGrpcServiceTest.java
@@ -24,6 +24,8 @@ import bisq.core.dao.state.model.blockchain.Block;
 import io.grpc.stub.StreamObserver;
 
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.mockito.ArgumentCaptor;
@@ -104,6 +106,59 @@ public class BsqBlockGrpcServiceTest {
         assertEquals(941_122, events.get(0).getSubscriptionReadyHeight());
         assertEquals(BsqBlockSubscriptionEvent.PayloadCase.BSQBLOCK, events.get(1).getPayloadCase());
         assertEquals(941_123, events.get(1).getBsqBlock().getHeight());
+    }
+
+    @Test
+    public void snapshotSubscriptionQueuesReadyEventBeforeConcurrentBlockPublication() throws Exception {
+        CountDownLatch registeredButReadyEventNotQueued = new CountDownLatch(1);
+        CountDownLatch releaseChainHeightRead = new CountDownLatch(1);
+        when(daoStateService.getChainHeight()).thenAnswer(invocation -> {
+            registeredButReadyEventNotQueued.countDown();
+            if (!releaseChainHeightRead.await(5, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Chain height read was never released");
+            }
+            return 941_122;
+        });
+        Block block = mock(Block.class);
+        when(block.getHeight()).thenReturn(941_123);
+        when(block.getTime()).thenReturn(1_723_000_000L);
+        when(block.getTxs()).thenReturn(List.of());
+        @SuppressWarnings("unchecked")
+        StreamObserver<BsqBlockSubscriptionEvent> streamObserver = mock(StreamObserver.class);
+
+        Thread subscriber = new Thread(() ->
+                service.subscribeWithSnapshot(BsqBlockSubscription.getDefaultInstance(), streamObserver));
+        subscriber.start();
+        assertTrue(registeredButReadyEventNotQueued.await(5, TimeUnit.SECONDS));
+
+        // The observer is registered but its ready event is not queued yet, which is the window in which a block
+        // must not be queued ahead of it.
+        Thread publisher = new Thread(() -> service.onParseBlockCompleteAfterBatchProcessing(block));
+        publisher.start();
+        awaitContendedOrDone(publisher);
+        releaseChainHeightRead.countDown();
+        subscriber.join(5_000);
+        publisher.join(5_000);
+
+        ArgumentCaptor<BsqBlockSubscriptionEvent> eventCaptor = ArgumentCaptor.forClass(BsqBlockSubscriptionEvent.class);
+        verify(streamObserver, timeout(2_000).times(2)).onNext(eventCaptor.capture());
+        List<BsqBlockSubscriptionEvent> events = eventCaptor.getAllValues();
+        assertEquals(BsqBlockSubscriptionEvent.PayloadCase.SUBSCRIPTIONREADYHEIGHT, events.get(0).getPayloadCase());
+        assertEquals(BsqBlockSubscriptionEvent.PayloadCase.BSQBLOCK, events.get(1).getPayloadCase());
+    }
+
+    // The publisher either contends on the subscription lock or, if that ordering is not enforced, runs to
+    // completion. Both are terminal for this test, so we gate on the state instead of timing the handover.
+    private static void awaitContendedOrDone(Thread thread) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (System.nanoTime() < deadline) {
+            Thread.State state = thread.getState();
+            if (state == Thread.State.BLOCKED || state == Thread.State.TERMINATED) {
+                return;
+            }
+            Thread.onSpinWait();
+        }
+        throw new IllegalStateException("Publisher thread neither blocked nor completed");
     }
 
     @Test

--- a/bridge/src/test/java/bisq/bridge/grpc/services/BsqBlockGrpcServiceTest.java
+++ b/bridge/src/test/java/bisq/bridge/grpc/services/BsqBlockGrpcServiceTest.java
@@ -26,6 +26,7 @@ import io.grpc.stub.StreamObserver;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import org.mockito.ArgumentCaptor;
@@ -35,9 +36,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -87,6 +92,31 @@ public class BsqBlockGrpcServiceTest {
     }
 
     @Test
+    public void failingObserverIsDeregisteredAndDoesNotBlockRemainingObservers() {
+        Block block = mock(Block.class);
+        when(block.getHeight()).thenReturn(941_123);
+        when(block.getTime()).thenReturn(1_723_000_000L);
+        when(block.getTxs()).thenReturn(List.of());
+        @SuppressWarnings("unchecked")
+        StreamObserver<BsqBlockDto> failing = mock(StreamObserver.class);
+        doThrow(new IllegalStateException("stream broken")).when(failing).onNext(any());
+        doThrow(new IllegalStateException("call already closed")).when(failing).onError(any());
+        @SuppressWarnings("unchecked")
+        StreamObserver<BsqBlockDto> healthy = mock(StreamObserver.class);
+        // Registration order matters: the failing observer is notified first.
+        service.subscribe(BsqBlockSubscription.getDefaultInstance(), failing);
+        service.subscribe(BsqBlockSubscription.getDefaultInstance(), healthy);
+
+        service.onParseBlockCompleteAfterBatchProcessing(block);
+        verify(healthy, timeout(2_000)).onNext(any());
+
+        // The failing observer was deregistered even though its onError threw, so a second block skips it.
+        service.onParseBlockCompleteAfterBatchProcessing(block);
+        verify(healthy, timeout(2_000).times(2)).onNext(any());
+        verify(failing, times(1)).onNext(any());
+    }
+
+    @Test
     public void snapshotSubscriptionAcknowledgesRegistrationBeforePublishingBlocks() {
         when(daoStateService.getChainHeight()).thenReturn(941_122);
         Block block = mock(Block.class);
@@ -126,19 +156,25 @@ public class BsqBlockGrpcServiceTest {
         @SuppressWarnings("unchecked")
         StreamObserver<BsqBlockSubscriptionEvent> streamObserver = mock(StreamObserver.class);
 
+        AtomicReference<Throwable> subscriberFailure = new AtomicReference<>();
+        AtomicReference<Throwable> publisherFailure = new AtomicReference<>();
         Thread subscriber = new Thread(() ->
                 service.subscribeWithSnapshot(BsqBlockSubscription.getDefaultInstance(), streamObserver));
+        subscriber.setUncaughtExceptionHandler((thread, throwable) -> subscriberFailure.set(throwable));
         subscriber.start();
         assertTrue(registeredButReadyEventNotQueued.await(5, TimeUnit.SECONDS));
 
         // The observer is registered but its ready event is not queued yet, which is the window in which a block
         // must not be queued ahead of it.
         Thread publisher = new Thread(() -> service.onParseBlockCompleteAfterBatchProcessing(block));
+        publisher.setUncaughtExceptionHandler((thread, throwable) -> publisherFailure.set(throwable));
         publisher.start();
         awaitContendedOrDone(publisher);
         releaseChainHeightRead.countDown();
         subscriber.join(5_000);
         publisher.join(5_000);
+        assertNull(subscriberFailure.get());
+        assertNull(publisherFailure.get());
 
         ArgumentCaptor<BsqBlockSubscriptionEvent> eventCaptor = ArgumentCaptor.forClass(BsqBlockSubscriptionEvent.class);
         verify(streamObserver, timeout(2_000).times(2)).onNext(eventCaptor.capture());

--- a/bridge/src/test/java/bisq/bridge/grpc/services/BsqBlockGrpcServiceTest.java
+++ b/bridge/src/test/java/bisq/bridge/grpc/services/BsqBlockGrpcServiceTest.java
@@ -39,8 +39,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -109,6 +111,7 @@ public class BsqBlockGrpcServiceTest {
 
         service.onParseBlockCompleteAfterBatchProcessing(block);
         verify(healthy, timeout(2_000)).onNext(any());
+        verify(failing, times(1)).onError(any());
 
         // The failing observer was deregistered even though its onError threw, so a second block skips it.
         service.onParseBlockCompleteAfterBatchProcessing(block);
@@ -136,6 +139,64 @@ public class BsqBlockGrpcServiceTest {
         assertEquals(941_122, events.get(0).getSubscriptionReadyHeight());
         assertEquals(BsqBlockSubscriptionEvent.PayloadCase.BSQBLOCK, events.get(1).getPayloadCase());
         assertEquals(941_123, events.get(1).getBsqBlock().getHeight());
+    }
+
+    @Test
+    public void snapshotSubscriptionSetupFailureDeregistersTheObserver() {
+        when(daoStateService.getChainHeight())
+                .thenThrow(new IllegalStateException("dao state unavailable"))
+                .thenReturn(941_122);
+        Block block = mock(Block.class);
+        when(block.getHeight()).thenReturn(941_123);
+        when(block.getTime()).thenReturn(1_723_000_000L);
+        when(block.getTxs()).thenReturn(List.of());
+        @SuppressWarnings("unchecked")
+        StreamObserver<BsqBlockSubscriptionEvent> failedSetup = mock(StreamObserver.class);
+        @SuppressWarnings("unchecked")
+        StreamObserver<BsqBlockSubscriptionEvent> healthy = mock(StreamObserver.class);
+
+        service.subscribeWithSnapshot(BsqBlockSubscription.getDefaultInstance(), failedSetup);
+        verify(failedSetup).onError(any());
+        service.subscribeWithSnapshot(BsqBlockSubscription.getDefaultInstance(), healthy);
+
+        service.onParseBlockCompleteAfterBatchProcessing(block);
+
+        // The healthy observer receiving both events proves the publication ran, so the failed one was skipped.
+        verify(healthy, timeout(2_000).times(2)).onNext(any());
+        verify(failedSetup, never()).onNext(any());
+    }
+
+    @Test
+    public void snapshotObserverRemovedByFailedReadinessEventIsSkippedByQueuedBlock() throws Exception {
+        when(daoStateService.getChainHeight()).thenReturn(941_122);
+        Block block = mock(Block.class);
+        when(block.getHeight()).thenReturn(941_123);
+        when(block.getTime()).thenReturn(1_723_000_000L);
+        when(block.getTxs()).thenReturn(List.of());
+        CountDownLatch readinessEventEntered = new CountDownLatch(1);
+        CountDownLatch releaseReadinessEvent = new CountDownLatch(1);
+        @SuppressWarnings("unchecked")
+        StreamObserver<BsqBlockSubscriptionEvent> failing = mock(StreamObserver.class);
+        doAnswer(invocation -> {
+            readinessEventEntered.countDown();
+            if (!releaseReadinessEvent.await(5, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Readiness event was never released");
+            }
+            throw new IllegalStateException("stream broken");
+        }).when(failing).onNext(any());
+        @SuppressWarnings("unchecked")
+        StreamObserver<BsqBlockSubscriptionEvent> healthy = mock(StreamObserver.class);
+        service.subscribeWithSnapshot(BsqBlockSubscription.getDefaultInstance(), failing);
+        service.subscribeWithSnapshot(BsqBlockSubscription.getDefaultInstance(), healthy);
+
+        // Hold the executor inside the failing readiness event so the block is captured while it is still
+        // registered, and only then let that event fail and deregister it.
+        assertTrue(readinessEventEntered.await(5, TimeUnit.SECONDS));
+        service.onParseBlockCompleteAfterBatchProcessing(block);
+        releaseReadinessEvent.countDown();
+
+        verify(healthy, timeout(2_000).times(2)).onNext(any());
+        verify(failing, times(1)).onNext(any());
     }
 
     @Test

--- a/bridge/src/test/java/bisq/bridge/grpc/services/BurningmanGrpcServiceTest.java
+++ b/bridge/src/test/java/bisq/bridge/grpc/services/BurningmanGrpcServiceTest.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.bridge.grpc.services;
+
+import bisq.core.dao.burningman.BurningManService;
+import bisq.core.dao.burningman.DelayedPayoutTxReceiverService;
+import bisq.core.dao.state.DaoStateService;
+import bisq.core.dao.state.model.blockchain.Block;
+
+import io.grpc.stub.StreamObserver;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+
+import bisq.bridge.protobuf.BurningmanBlockDto;
+import bisq.bridge.protobuf.BurningmanBlockSubscription;
+
+public class BurningmanGrpcServiceTest {
+    private static final int BLOCK_HEIGHT = 941_123;
+    private static final int SELECTION_HEIGHT = 941_120;
+
+    private BurningManService burningManService;
+    private BurningmanGrpcService service;
+    private Block block;
+
+    @BeforeEach
+    public void setUp() {
+        DaoStateService daoStateService = mock(DaoStateService.class);
+        burningManService = mock(BurningManService.class);
+        DelayedPayoutTxReceiverService delayedPayoutTxReceiverService = mock(DelayedPayoutTxReceiverService.class);
+        block = mock(Block.class);
+        when(block.getHeight()).thenReturn(BLOCK_HEIGHT);
+        when(delayedPayoutTxReceiverService.getBurningManSelectionHeight(BLOCK_HEIGHT)).thenReturn(SELECTION_HEIGHT);
+        when(daoStateService.getBlockAtHeight(SELECTION_HEIGHT)).thenReturn(Optional.of(block));
+        service = new BurningmanGrpcService(daoStateService, burningManService, delayedPayoutTxReceiverService);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        service.shutDown();
+    }
+
+    @Test
+    public void failingObserverDoesNotBlockErrorSignallingOfRemainingObservers() {
+        when(burningManService.getActiveBurningManCandidates(BLOCK_HEIGHT))
+                .thenThrow(new IllegalStateException("candidate lookup failed"));
+        @SuppressWarnings("unchecked")
+        StreamObserver<BurningmanBlockDto> failing = mock(StreamObserver.class);
+        doThrow(new IllegalStateException("call already closed")).when(failing).onError(any());
+        @SuppressWarnings("unchecked")
+        StreamObserver<BurningmanBlockDto> healthy = mock(StreamObserver.class);
+        // Registration order matters: the failing observer is signalled first.
+        service.subscribe(BurningmanBlockSubscription.getDefaultInstance(), failing);
+        service.subscribe(BurningmanBlockSubscription.getDefaultInstance(), healthy);
+
+        service.onParseBlockCompleteAfterBatchProcessing(block);
+
+        verify(healthy, timeout(2_000)).onError(any());
+    }
+}


### PR DESCRIPTION
aims to resolve CI test failure

subscribeWithSnapshot registered the observer inside a task submitted to notifyObserversExecutor. onParseBlockCompleteAfterBatchProcessing checks the observer sets on the caller thread and returns early when both are empty, so a block parsed while the registration task was still queued was never delivered to that subscriber. This made BsqBlockGrpcServiceTest flaky.

Register the observer and read the chain height on the calling thread, and keep only the subscriptionReadyHeight event on the executor. Registering before reading the height means a block parsed in between is delivered on the stream and may also fall within the snapshot range, which is a duplicate rather than a gap.

Snapshot observers are now captured when the block is raised so a client subscribing afterwards cannot receive the block ahead of its ready event; the height it gets already covers the block, so it backfills via requestBsqBlocks. Plain subscribers keep live iteration since they have no such handshake and no backfill signal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of blockchain snapshot notifications during subscription setup.
  * Prevented blocks from being missed when they arrive while a snapshot subscription is being initialized.
  * Ensured errors are delivered consistently to subscribers captured for the snapshot.
  * Preserved the correct ordering of readiness notifications before subsequent block updates.
  * Prevented failing observers from blocking healthy subscribers or interrupting error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->