### PR TITLE
Suppress deprecation warnings for ArbitrationManager

### DIFF
--- a/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
+++ b/core/src/main/java/bisq/core/proto/network/CoreNetworkProtoResolver.java
@@ -279,6 +279,7 @@ public class CoreNetworkProtoResolver extends CoreProtoResolver implements Netwo
         }
     }
 
+    @SuppressWarnings("deprecation")
     public NetworkPayload fromProto(protobuf.StoragePayload proto) {
         if (proto != null) {
             switch (proto.getMessageCase()) {

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionAwareTrade.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionAwareTrade.java
@@ -51,6 +51,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Slf4j
 class TransactionAwareTrade implements TransactionAwareTradable {
     private final TradeModel tradeModel;
+    @SuppressWarnings("deprecation")
     private final ArbitrationManager arbitrationManager;
     private final RefundManager refundManager;
     private final BtcWalletService btcWalletService;
@@ -62,7 +63,7 @@ class TransactionAwareTrade implements TransactionAwareTradable {
     private static Tuple2<String, Set<String>> lastReceiverAddressStringsTuple;
 
     TransactionAwareTrade(TradeModel tradeModel,
-                          ArbitrationManager arbitrationManager,
+                          @SuppressWarnings("deprecation") ArbitrationManager arbitrationManager,
                           RefundManager refundManager,
                           BtcWalletService btcWalletService,
                           PubKeyRing pubKeyRing) {

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
@@ -128,6 +128,7 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
     private final WalletsSetup walletsSetup;
     private final Preferences preferences;
     private final TradableRepository tradableRepository;
+    @SuppressWarnings("deprecation")
     private final ArbitrationManager arbitrationManager;
     private final RefundManager refundManager;
     private final PubKeyRing pubKeyRing;
@@ -153,7 +154,7 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
                              WalletsSetup walletsSetup,
                              Preferences preferences,
                              TradableRepository tradableRepository,
-                             ArbitrationManager arbitrationManager,
+                             @SuppressWarnings("deprecation") ArbitrationManager arbitrationManager,
                              RefundManager refundManager,
                              PubKeyRing pubKeyRing,
                              TradeDetailsWindow tradeDetailsWindow,

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/ContractWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/ContractWindow.java
@@ -77,6 +77,7 @@ import static bisq.desktop.util.FormBuilder.*;
 
 @Slf4j
 public class ContractWindow extends Overlay<ContractWindow> {
+    @SuppressWarnings("deprecation")
     private final ArbitrationManager arbitrationManager;
     private final MediationManager mediationManager;
     private final RefundManager refundManager;
@@ -90,7 +91,7 @@ public class ContractWindow extends Overlay<ContractWindow> {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     @Inject
-    public ContractWindow(ArbitrationManager arbitrationManager,
+    public ContractWindow(@SuppressWarnings("deprecation") ArbitrationManager arbitrationManager,
                           MediationManager mediationManager,
                           RefundManager refundManager,
                           AccountAgeWitnessService accountAgeWitnessService,

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TradeDetailsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TradeDetailsWindow.java
@@ -83,6 +83,7 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
     protected static final Logger log = LoggerFactory.getLogger(TradeDetailsWindow.class);
 
     private final CoinFormatter formatter;
+    @SuppressWarnings("deprecation")
     private final ArbitrationManager arbitrationManager;
     private final TradeManager tradeManager;
     private final BtcWalletService btcWalletService;
@@ -100,7 +101,7 @@ public class TradeDetailsWindow extends Overlay<TradeDetailsWindow> {
 
     @Inject
     public TradeDetailsWindow(@Named(FormattingUtils.BTC_FORMATTER_KEY) CoinFormatter formatter,
-                              ArbitrationManager arbitrationManager,
+                              @SuppressWarnings("deprecation") ArbitrationManager arbitrationManager,
                               TradeManager tradeManager,
                               BtcWalletService btcWalletService,
                               AccountAgeWitnessService accountAgeWitnessService) {

--- a/desktop/src/main/java/bisq/desktop/main/support/SupportView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/SupportView.java
@@ -68,6 +68,7 @@ public class SupportView extends ActivatableView<TabPane, Void> {
     private final Navigation navigation;
     private final MediatorManager mediatorManager;
     private final RefundAgentManager refundAgentManager;
+    @SuppressWarnings("deprecation")
     private final ArbitrationManager arbitrationManager;
     private final MediationManager mediationManager;
     private final RefundManager refundManager;
@@ -85,7 +86,7 @@ public class SupportView extends ActivatableView<TabPane, Void> {
                        Navigation navigation,
                        MediatorManager mediatorManager,
                        RefundAgentManager refundAgentManager,
-                       ArbitrationManager arbitrationManager,
+                       @SuppressWarnings("deprecation") ArbitrationManager arbitrationManager,
                        MediationManager mediationManager,
                        RefundManager refundManager,
                        KeyRing keyRing) {

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/client/arbitration/ArbitrationClientView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/client/arbitration/ArbitrationClientView.java
@@ -49,7 +49,7 @@ import javax.inject.Named;
 @FxmlView
 public class ArbitrationClientView extends DisputeClientView {
     @Inject
-    public ArbitrationClientView(ArbitrationManager arbitrationManager,
+    public ArbitrationClientView(@SuppressWarnings("deprecation") ArbitrationManager arbitrationManager,
                                  KeyRing keyRing,
                                  P2PService p2PService,
                                  TradeManager tradeManager,


### PR DESCRIPTION
ArbitrationManager was recently deprecated, but the codebase still contains numerous references to it. This change temporarily suppresses the resulting deprecation warnings to keep the build output clean while we migrate to the new implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Cleaned up deprecation warnings across network, trading, transaction, support, and dispute-related components.
  - No user-facing behavior or functionality has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->