### PR TITLE
Replace deprecated Charsets.UTF_8 with StandardCharsets.UTF_8

### DIFF
--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/maker/MakerProcessesInputsForDepositTxRequest.java
@@ -47,6 +47,8 @@ import com.google.common.base.Charsets;
 
 import java.security.PublicKey;
 
+import java.nio.charset.StandardCharsets;
+
 import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
@@ -128,7 +130,7 @@ public class MakerProcessesInputsForDepositTxRequest extends TradeTask {
 
             // Taker has to sign offerId (he cannot manipulate that - so we avoid to have a challenge protocol for
             // passing the nonce we want to get signed)
-            byte[] accountAgeWitnessNonce = trade.getId().getBytes(Charsets.UTF_8);
+            byte[] accountAgeWitnessNonce = trade.getId().getBytes(StandardCharsets.UTF_8);
             PublicKey takerSignatureKey = takerPubKeyRing.getSignaturePubKey();
             byte[] accountAgeWitnessSignature = checkDSASignature(request.getAccountAgeWitnessSignatureOfOfferId(),
                     accountAgeWitnessNonce,

--- a/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerSendInputsForDepositTxRequest.java
+++ b/core/src/main/java/bisq/core/trade/protocol/bisq_v1/tasks/taker/TakerSendInputsForDepositTxRequest.java
@@ -37,6 +37,8 @@ import org.bitcoinj.core.Coin;
 
 import com.google.common.base.Charsets;
 
+import java.nio.charset.StandardCharsets;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -101,7 +103,7 @@ public class TakerSendInputsForDepositTxRequest extends TradeTask {
             // protocol for passing the nonce we want to get signed)
             // This is used for verifying the peers account age witness
             byte[] signatureOfNonce = Sig.sign(processModel.getKeyRing().getSignatureKeyPair().getPrivate(),
-                    offerId.getBytes(Charsets.UTF_8));
+                    offerId.getBytes(StandardCharsets.UTF_8));
 
             int burningManSelectionHeight = processModel.getDelayedPayoutTxReceiverService().getBurningManSelectionHeight();
             processModel.setBurningManSelectionHeight(burningManSelectionHeight);

--- a/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
+++ b/desktop/src/main/java/bisq/desktop/components/PeerInfoIcon.java
@@ -48,6 +48,8 @@ import javafx.beans.property.StringProperty;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+import java.nio.charset.StandardCharsets;
+
 import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
@@ -87,7 +89,7 @@ public class PeerInfoIcon extends Group {
         int intValue = 0;
         try {
             MessageDigest md = MessageDigest.getInstance("SHA1");
-            byte[] bytes = md.digest(fullAddress.getBytes(Charsets.UTF_8));
+            byte[] bytes = md.digest(fullAddress.getBytes(StandardCharsets.UTF_8));
             intValue = Math.abs(((bytes[0] & 0xFF) << 24) | ((bytes[1] & 0xFF) << 16)
                     | ((bytes[2] & 0xFF) << 8) | (bytes[3] & 0xFF));
 

--- a/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/MainViewModel.java
@@ -112,6 +112,8 @@ import javafx.beans.property.StringProperty;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 
+import java.nio.charset.StandardCharsets;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
@@ -421,7 +423,7 @@ public class MainViewModel implements ViewModel, BisqSetup.BisqSetupListener {
         });
         bisqSetup.setLockedUpFundsHandler(msg -> {
             // repeated popups of the same message text can be stopped by selecting the "Dont show again" checkbox
-            String key = Hex.encode(Hash.getSha256Ripemd160hash(msg.getBytes(Charsets.UTF_8)));
+            String key = Hex.encode(Hash.getSha256Ripemd160hash(msg.getBytes(StandardCharsets.UTF_8)));
             if (preferences.showAgain(key)) {
                 new Popup().width(850).warning(msg)
                         .dontShowAgainId(key)

--- a/desktop/src/main/java/bisq/desktop/main/dao/bonding/reputation/MyReputationView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/bonding/reputation/MyReputationView.java
@@ -69,6 +69,8 @@ import javafx.collections.transformation.SortedList;
 
 import javafx.util.Callback;
 
+import java.nio.charset.StandardCharsets;
+
 import java.util.Comparator;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -264,7 +266,7 @@ public class MyReputationView extends ActivatableView<GridPane, Void> implements
     }
 
     private void setNewRandomSalt() {
-        byte[] randomBytes = UUID.randomUUID().toString().getBytes(Charsets.UTF_8);
+        byte[] randomBytes = UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8);
         // We want to limit it to 20 bytes
         byte[] hashOfRandomBytes = Hash.getSha256Ripemd160hash(randomBytes);
         // bytesAsHexString results in 40 chars

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/send/BsqSendView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/send/BsqSendView.java
@@ -85,6 +85,8 @@ import javafx.scene.layout.VBox;
 
 import javafx.beans.value.ChangeListener;
 
+import java.nio.charset.StandardCharsets;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -517,7 +519,7 @@ public class BsqSendView extends ActivatableView<GridPane, Void> implements BsqB
             // If preImage is hex encoded we use it directly
             opReturnData = Hex.decode(preImageAsString);
         } catch (Throwable ignore) {
-            opReturnData = preImageAsString.getBytes(Charsets.UTF_8);
+            opReturnData = preImageAsString.getBytes(StandardCharsets.UTF_8);
         }
 
         // If too long for OpReturn we hash it

--- a/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
+++ b/desktop/src/main/java/bisq/desktop/util/GUIUtil.java
@@ -137,6 +137,7 @@ import java.security.KeyPair;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -418,7 +419,7 @@ public class GUIUtil {
         fileChooser.setInitialFileName(fileName);
         File file = fileChooser.showSaveDialog(stage);
         if (file != null) {
-            try (OutputStreamWriter outputStreamWriter = new OutputStreamWriter(new FileOutputStream(file, false), Charsets.UTF_8)) {
+            try (OutputStreamWriter outputStreamWriter = new OutputStreamWriter(new FileOutputStream(file, false), StandardCharsets.UTF_8)) {
                 CSVWriter<T> headerWriter = new CSVWriterBuilder<T>(outputStreamWriter)
                         .strategy(CSVStrategy.UK_DEFAULT)
                         .entryConverter(headerConverter)
@@ -443,7 +444,7 @@ public class GUIUtil {
         fileChooser.setInitialFileName(fileName);
         File file = fileChooser.showSaveDialog(stage);
         if (file != null) {
-            try (OutputStreamWriter outputStreamWriter = new OutputStreamWriter(new FileOutputStream(file, false), Charsets.UTF_8)) {
+            try (OutputStreamWriter outputStreamWriter = new OutputStreamWriter(new FileOutputStream(file, false), StandardCharsets.UTF_8)) {
                 Gson gson = new GsonBuilder().setPrettyPrinting().create();
                 outputStreamWriter.write(gson.toJson(data));
             } catch (RuntimeException | IOException e) {


### PR DESCRIPTION
StandardCharsets is built into Java 7+, allowing us to rely on the standard library instead of the deprecated Guava implementation. This helps reduce our reliance on external dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized UTF-8 text encoding across trade processing, peer information, reputation, wallet, hashing, and data export features.
  * Replaced an internal charset reference with Java’s standard UTF-8 implementation.
  * No user-visible behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->