### PR TITLE
Replace deprecated URL constructor with URI.toURL()

### DIFF
--- a/core/src/main/java/bisq/core/util/validation/UrlInputValidator.java
+++ b/core/src/main/java/bisq/core/util/validation/UrlInputValidator.java
@@ -19,7 +19,7 @@ package bisq.core.util.validation;
 
 import bisq.core.locale.Res;
 
-import java.net.URL;
+import java.net.URI;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -34,7 +34,7 @@ public class UrlInputValidator extends InputValidator {
             return validationResult;
 
         try {
-            new URL(input); // does not cover all invalid urls, so we use a regex as well
+            new URI(input).toURL(); // does not cover all invalid urls, so we use a regex as well
             String regex = "^(https?)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]";
             checkArgument(input.matches(regex), "URL does not match regex");
             return validationResult;

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/downloadupdate/DownloadTask.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/downloadupdate/DownloadTask.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Lists;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
+import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 
@@ -99,7 +100,7 @@ public class DownloadTask extends Task<List<BisqInstaller.FileDescriptor>> {
                     log.info("Downloading {}", fileDescriptor.getLoadUrl());
                     try {
                         updateMessage(fileDescriptor.getFileName());
-                        download(new URL(fileDescriptor.getLoadUrl()), fileDescriptor.getSaveFile());
+                        download(new URI(fileDescriptor.getLoadUrl()).toURL(), fileDescriptor.getSaveFile());
                         log.info("Download for {} done", fileDescriptor.getLoadUrl());
                         fileDescriptor.setDownloadStatus(BisqInstaller.DownloadStatusEnum.OK);
                     } catch (Exception e) {


### PR DESCRIPTION
The java.net.URL constructors were deprecated in Java 20. This updates the code to use the recommended approach: parsing a URI string and converting it via URI.toURL(), which ensures better syntax validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL validation for greater compatibility with standard URL formats.
  * Improved reliability when preparing update downloads from URL-based sources.
  * Existing download error handling remains in place for invalid or unreachable URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->