### PR TITLE
Update deprecated TableView resize policy

### DIFF
--- a/desktop/src/main/java/bisq/desktop/main/account/content/notifications/ManageMarketAlertsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/notifications/ManageMarketAlertsWindow.java
@@ -89,7 +89,7 @@ public class ManageMarketAlertsWindow extends Overlay<ManageMarketAlertsWindow> 
         placeholder.setWrapText(true);
         tableView.setPlaceholder(placeholder);
         tableView.setPrefHeight(300);
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
 
         setColumns(tableView);
         tableView.setItems(FXCollections.observableArrayList(marketAlerts.getMarketAlertFilters()));

--- a/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/burningman/BurningManView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/burnbsq/burningman/BurningManView.java
@@ -513,7 +513,7 @@ public class BurningManView extends ActivatableView<ScrollPane, Void> implements
         GridPane.setMargin(balanceEntryTableView, new Insets(60, -10, 5, -10));
         gridPane.getChildren().add(balanceEntryTableView);
         balanceEntryTableView.setPlaceholder(new AutoTooltipLabel(Res.get("table.placeholder.noData")));
-        balanceEntryTableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        balanceEntryTableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         createBalanceEntryColumns();
         balanceEntryTableView.setItems(balanceEntrySortedList);
         balanceEntryTableView.setVisible(false);

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/proposals/ProposalsView.java
@@ -659,7 +659,7 @@ public class ProposalsView extends ActivatableView<GridPane, Void> implements Bs
 
         tableView = new TableView<>();
         tableView.setPlaceholder(new AutoTooltipLabel(Res.get("table.placeholder.noData")));
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
 
         createProposalColumns();
         GridPane.setRowIndex(tableView, gridRow);

--- a/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/governance/result/VoteResultView.java
@@ -446,7 +446,7 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
 
         cyclesTableView = new TableView<>();
         cyclesTableView.setPlaceholder(new AutoTooltipLabel(Res.get("table.placeholder.processingData")));
-        cyclesTableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        cyclesTableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
 
         createCycleColumns(cyclesTableView);
 
@@ -474,7 +474,7 @@ public class VoteResultView extends ActivatableView<GridPane, Void> implements D
 
         proposalsTableView = new TableView<>();
         proposalsTableView.setPlaceholder(new AutoTooltipLabel(Res.get("table.placeholder.noData")));
-        proposalsTableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        proposalsTableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
 
         createProposalsColumns(proposalsTableView);
 

--- a/desktop/src/main/java/bisq/desktop/main/dao/monitor/StateMonitorView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/monitor/StateMonitorView.java
@@ -207,7 +207,7 @@ public abstract class StateMonitorView<StH extends StateHash,
 
         tableView = new TableView<>();
         tableView.setPlaceholder(new AutoTooltipLabel(Res.get("table.placeholder.noData")));
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         tableView.setPrefHeight(100);
 
         createColumns();
@@ -228,7 +228,7 @@ public abstract class StateMonitorView<StH extends StateHash,
 
         conflictTableView = new TableView<>();
         conflictTableView.setPlaceholder(new AutoTooltipLabel(Res.get("table.placeholder.noData")));
-        conflictTableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        conflictTableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         conflictTableView.setPrefHeight(100);
 
         createConflictColumns();

--- a/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
+++ b/desktop/src/main/java/bisq/desktop/main/dao/wallet/tx/BsqTxView.java
@@ -148,7 +148,7 @@ public class BsqTxView extends ActivatableView<GridPane, Void> implements BsqBal
         gridRow = bsqBalanceUtil.addGroup(root, gridRow);
 
         tableView = new TableView<>();
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
 
         addDateColumn();
         addTxIdColumn();

--- a/desktop/src/main/java/bisq/desktop/main/funds/deposit/DepositView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/deposit/DepositView.java
@@ -150,7 +150,7 @@ public class DepositView extends ActivatableView<VBox, Void> {
         // trigger creation of at least 1 savings address
         walletService.getFreshAddressEntry();
 
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         tableView.setPlaceholder(new AutoTooltipLabel(Res.get("funds.deposit.noAddresses")));
         tableViewSelectionListener = (observableValue, oldValue, newValue) -> {
             if (newValue != null) {

--- a/desktop/src/main/java/bisq/desktop/main/funds/locked/LockedView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/locked/LockedView.java
@@ -138,7 +138,7 @@ public class LockedView extends ActivatableView<VBox, Void> {
         addressColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.address")));
         balanceColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.balanceWithCur", Res.getBaseCurrencyCode())));
 
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         tableView.setPlaceholder(new AutoTooltipLabel(Res.get("funds.locked.noFunds")));
 
         setTradeIdColumnCellFactory();

--- a/desktop/src/main/java/bisq/desktop/main/funds/reserved/ReservedView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/reserved/ReservedView.java
@@ -138,7 +138,7 @@ public class ReservedView extends ActivatableView<VBox, Void> {
         addressColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.address")));
         balanceColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.balanceWithCur", Res.getBaseCurrencyCode())));
 
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         tableView.setPlaceholder(new AutoTooltipLabel(Res.get("funds.reserved.noFunds")));
 
         setDateColumnCellFactory();

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsView.java
@@ -188,7 +188,7 @@ public class TransactionsView extends ActivatableView<VBox, Void> {
         confidenceColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.confirmations", Res.getBaseCurrencyCode())));
         revertTxColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.revert", Res.getBaseCurrencyCode())));
 
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         tableView.setPlaceholder(new AutoTooltipLabel(Res.get("funds.tx.noTxAvailable")));
 
         setDateColumnCellFactory();

--- a/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalView.java
@@ -288,7 +288,7 @@ public class WithdrawalView extends ActivatableView<VBox, Void> {
         balanceColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.balanceWithCur", Res.getBaseCurrencyCode())));
         selectColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.select")));
 
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         tableView.setMaxHeight(Double.MAX_VALUE);
         tableView.setPlaceholder(new AutoTooltipLabel(Res.get("funds.withdrawal.noFundsAvailable")));
         tableView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);

--- a/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/offerbook/OfferBookChartView.java
@@ -631,7 +631,7 @@ public class OfferBookChartView extends ActivatableViewAndModel<VBox, OfferBookC
         tableView.getColumns().add(priceColumn);
         tableView.getColumns().add(avatarColumn);
 
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         Label placeholder = new AutoTooltipLabel(Res.get("table.placeholder.noItems", Res.get("shared.multipleOffers")));
         placeholder.setWrapText(true);
         tableView.setPlaceholder(placeholder);

--- a/desktop/src/main/java/bisq/desktop/main/market/spread/SpreadView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/spread/SpreadView.java
@@ -93,7 +93,7 @@ public class SpreadView extends ActivatableViewAndModel<GridPane, SpreadViewMode
         tableView.getColumns().add(totalAmountColumn);
         TableColumn<SpreadItem, SpreadItem> spreadColumn = getSpreadColumn();
         tableView.getColumns().add(spreadColumn);
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
 
         currencyColumn.setComparator(Comparator.comparing(o ->
                 model.isIncludePaymentMethod() ? o.currencyCode : CurrencyUtil.getNameByCode(o.currencyCode)));

--- a/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/market/trades/TradesChartsView.java
@@ -969,7 +969,7 @@ public class TradesChartsView extends ActivatableViewAndModel<VBox, TradesCharts
         paymentMethodColumn.setComparator(Comparator.comparing(TradeStatistics3ListItem::getPaymentMethodString));
         tableView.getColumns().add(paymentMethodColumn);
 
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         Label placeholder = new AutoTooltipLabel(Res.get("table.placeholder.noData"));
         placeholder.setWrapText(true);
         tableView.setPlaceholder(placeholder);

--- a/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
+++ b/desktop/src/main/java/bisq/desktop/main/offer/offerbook/OfferBookView.java
@@ -269,7 +269,7 @@ abstract public class OfferBookView<R extends GridPane, M extends OfferBookViewM
         tableView.getColumns().add(avatarColumn);
 
         tableView.getSortOrder().add(priceColumn);
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         Label placeholder = new AutoTooltipLabel(Res.get("table.placeholder.noItems", Res.get("shared.multipleOffers")));
         placeholder.setWrapText(true);
         tableView.setPlaceholder(placeholder);

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/ProposalResultsWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/ProposalResultsWindow.java
@@ -198,7 +198,7 @@ public class ProposalResultsWindow extends TabbedOverlay<ProposalResultsWindow> 
 
         TableView<VoteListItem> votesTableView = new TableView<>();
         votesTableView.setPlaceholder(new AutoTooltipLabel(Res.get("table.placeholder.noData")));
-        votesTableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        votesTableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
 
         createColumns(votesTableView);
         GridPane.setRowIndex(votesTableView, gridRow);

--- a/desktop/src/main/java/bisq/desktop/main/overlays/windows/TxInputSelectionWindow.java
+++ b/desktop/src/main/java/bisq/desktop/main/overlays/windows/TxInputSelectionWindow.java
@@ -109,7 +109,7 @@ public class TxInputSelectionWindow extends Overlay<TxInputSelectionWindow> {
     protected void addContent() {
         tableView = new TableView<>();
         tableView.setPlaceholder(new AutoTooltipLabel(Res.get("table.placeholder.noData")));
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         GridPane.setRowIndex(tableView, rowIndex++);
         GridPane.setMargin(tableView, new Insets(Layout.GROUP_DISTANCE, 0, 0, 0));
         GridPane.setColumnSpan(tableView, 2);

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/bsqswaps/UnconfirmedBsqSwapsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/bsqswaps/UnconfirmedBsqSwapsView.java
@@ -162,7 +162,7 @@ public class UnconfirmedBsqSwapsView extends ActivatableViewAndModel<VBox, Uncon
         confidenceColumn.setGraphic(new AutoTooltipLabel(ColumnNames.CONF.toString()));
         avatarColumn.setText("");
 
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         tableView.setPlaceholder(new AutoTooltipLabel(Res.get("table.placeholder.noItems", Res.get("shared.trades"))));
 
         setTradeIdColumnCellFactory();

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesView.java
@@ -204,7 +204,7 @@ public class ClosedTradesView extends ActivatableViewAndModel<VBox, ClosedTrades
         duplicateColumn.setGraphic(new AutoTooltipLabel(""));
         avatarColumn.setText("");
 
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         tableView.setPlaceholder(new AutoTooltipLabel(Res.get("table.placeholder.noItems", Res.get("shared.trades"))));
 
         setTradeIdColumnCellFactory();

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesView.java
@@ -118,7 +118,7 @@ public class FailedTradesView extends ActivatableViewAndModel<VBox, FailedTrades
         tradeIdColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.tradeId")));
         stateColumn.setGraphic(new AutoTooltipLabel(Res.get("shared.state")));
 
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         tableView.setPlaceholder(new AutoTooltipLabel(Res.get("table.placeholder.noItems", Res.get("shared.trades"))));
 
         setTradeIdColumnCellFactory();

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/openoffer/OpenOffersView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/openoffer/OpenOffersView.java
@@ -200,7 +200,7 @@ public class OpenOffersView extends ActivatableViewAndModel<VBox, OpenOffersView
         setCloneColumnCellFactory();
         setRemoveColumnCellFactory();
 
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         tableView.setPlaceholder(new AutoTooltipLabel(Res.get("table.placeholder.noItems", Res.get("shared.openOffers"))));
 
         offerIdColumn.setComparator(Comparator.comparing(o -> o.getOffer().getId()));

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
@@ -208,7 +208,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
         setChatColumnCellFactory();
         setRemoveTradeColumnCellFactory();
 
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         tableView.setPlaceholder(new AutoTooltipLabel(Res.get("table.placeholder.noItems", Res.get("shared.openTrades"))));
         tableView.setMinHeight(100);
         tableView.setMaxHeight(350);

--- a/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/settings/network/NetworkSettingsView.java
@@ -203,7 +203,7 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
 
         bitcoinPeersTableView.setMinHeight(180);
         bitcoinPeersTableView.setPrefHeight(180);
-        bitcoinPeersTableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        bitcoinPeersTableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         bitcoinPeersTableView.setPlaceholder(new AutoTooltipLabel(Res.get("table.placeholder.noData")));
         bitcoinPeersTableView.getSortOrder().add(bitcoinPeerAddressColumn);
         bitcoinPeerAddressColumn.setSortType(TableColumn.SortType.ASCENDING);
@@ -211,7 +211,7 @@ public class NetworkSettingsView extends ActivatableView<GridPane, Void> {
 
         p2pPeersTableView.setMinHeight(180);
         p2pPeersTableView.setPrefHeight(180);
-        p2pPeersTableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        p2pPeersTableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         p2pPeersTableView.setPlaceholder(new AutoTooltipLabel(Res.get("table.placeholder.noData")));
         p2pPeersTableView.getSortOrder().add(creationDateColumn);
         creationDateColumn.setSortType(TableColumn.SortType.ASCENDING);

--- a/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
+++ b/desktop/src/main/java/bisq/desktop/main/support/dispute/DisputeView.java
@@ -940,7 +940,7 @@ public abstract class DisputeView extends ActivatableView<VBox, Void> implements
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     protected void setupTable() {
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         Label placeholder = new AutoTooltipLabel(Res.get("support.noTickets"));
         placeholder.setWrapText(true);
         tableView.setPlaceholder(placeholder);

--- a/desktop/src/main/java/bisq/desktop/util/FormBuilder.java
+++ b/desktop/src/main/java/bisq/desktop/util/FormBuilder.java
@@ -2431,7 +2431,7 @@ public class FormBuilder {
         GridPane.setMargin(tableView, new Insets(top + 30, -10, 5, -10));
         gridPane.getChildren().add(tableView);
         tableView.setPlaceholder(new AutoTooltipLabel(Res.get("table.placeholder.noData")));
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         return new Tuple2<>(tableView, titledGroupBg);
     }
 
@@ -2464,7 +2464,7 @@ public class FormBuilder {
         GridPane.setMargin(tableView, new Insets(top + 30, -10, 5, -10));
         gridPane.getChildren().add(tableView);
         tableView.setPlaceholder(new AutoTooltipLabel(Res.get("table.placeholder.noData")));
-        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
         return new Tuple3<>(filterField, tableView, hBox);
     }
 }


### PR DESCRIPTION
CONSTRAINED_RESIZE_POLICY was deprecated in JavaFX 20. This updates the code to use CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN as its official replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved table resizing throughout the desktop application.
  - The final column now expands to use available horizontal space, while other columns better retain their preferred widths.
  - Updated tables across market, trading, portfolio, funds, governance, network, transaction, and support screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->