### PR TITLE
Replace StringUtils with Strings.XX counterpart

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/AutocompleteComboBox.java
+++ b/desktop/src/main/java/bisq/desktop/components/AutocompleteComboBox.java
@@ -19,7 +19,7 @@ package bisq.desktop.components;
 
 import bisq.common.UserThread;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import bisq.desktop.components.controls.BisqJfxComboBox;
 import bisq.desktop.components.controls.skin.BisqComboBoxSkin;
@@ -164,7 +164,7 @@ public class AutocompleteComboBox<T> extends BisqJfxComboBox<T> {
     private void filterBy(String query) {
         matchingList = (extendedList != null && query.length() > 0 ? extendedList : list)
                 .stream()
-                .filter(item -> StringUtils.containsIgnoreCase(asString(item), query))
+                .filter(item -> Strings.CI.contains(asString(item), query))
                 .collect(Collectors.toList());
 
         setValue(null);

--- a/desktop/src/main/java/bisq/desktop/main/funds/deposit/DepositListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/deposit/DepositListItem.java
@@ -36,6 +36,7 @@ import org.bitcoinj.core.TransactionConfidence;
 import com.google.common.base.Suppliers;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import javafx.scene.control.Tooltip;
 
@@ -166,10 +167,10 @@ class DepositListItem implements FilterableListItem {
         if (filterString.isEmpty()) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getAddressString(), filterString)) {
+        if (Strings.CI.contains(getAddressString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getUsage(), filterString)) {
+        if (Strings.CI.contains(getUsage(), filterString)) {
             return true;
         }
         return getBalance().contains(filterString);

--- a/desktop/src/main/java/bisq/desktop/main/funds/locked/LockedListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/locked/LockedListItem.java
@@ -35,6 +35,7 @@ import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Transaction;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import javafx.scene.control.Label;
 
@@ -127,19 +128,19 @@ class LockedListItem implements FilterableListItem {
         if (filterString.isEmpty())
             return true;
 
-        if (StringUtils.containsIgnoreCase(getDetails(), filterString)) {
+        if (Strings.CI.contains(getDetails(), filterString)) {
             return true;
         }
 
-        if (StringUtils.containsIgnoreCase(getDateString(), filterString)) {
+        if (Strings.CI.contains(getDateString(), filterString)) {
             return true;
         }
 
-        if (StringUtils.containsIgnoreCase(getAddressString(), filterString)) {
+        if (Strings.CI.contains(getAddressString(), filterString)) {
             return true;
         }
 
-        if (StringUtils.containsIgnoreCase(getBalanceString(), filterString)) {
+        if (Strings.CI.contains(getBalanceString(), filterString)) {
             return true;
         }
 

--- a/desktop/src/main/java/bisq/desktop/main/funds/reserved/ReservedListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/reserved/ReservedListItem.java
@@ -34,6 +34,7 @@ import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Transaction;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import javafx.scene.control.Label;
 
@@ -124,16 +125,16 @@ class ReservedListItem implements FilterableListItem {
         if (filterString.isEmpty()) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getDetails(), filterString)) {
+        if (Strings.CI.contains(getDetails(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getAddressString(), filterString)) {
+        if (Strings.CI.contains(getAddressString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getDateAsString(), filterString)) {
+        if (Strings.CI.contains(getDateAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getBalanceString(), filterString)) {
+        if (Strings.CI.contains(getBalanceString(), filterString)) {
             return true;
         }
         return FilteringUtils.match(getOpenOffer().getOffer(), filterString);

--- a/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/transactions/TransactionsListItem.java
@@ -44,6 +44,7 @@ import org.bitcoinj.core.TransactionOutput;
 import com.google.common.base.Suppliers;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import javafx.scene.control.Tooltip;
 
@@ -361,24 +362,24 @@ class TransactionsListItem implements FilterableListItem {
         if (filterString.isEmpty()) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getTxId(), filterString)) {
+        if (Strings.CI.contains(getTxId(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getDetails(), filterString)) {
+        if (Strings.CI.contains(getDetails(), filterString)) {
             return true;
         }
-        if (getMemo() != null && StringUtils.containsIgnoreCase(getMemo(), filterString)) {
+        if (getMemo() != null && Strings.CI.contains(getMemo(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getDirection(), filterString)) {
+        if (Strings.CI.contains(getDirection(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getDateString(), filterString)) {
+        if (Strings.CI.contains(getDateString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getAmount(), filterString)) {
+        if (Strings.CI.contains(getAmount(), filterString)) {
             return true;
         }
-        return StringUtils.containsIgnoreCase(getAddressString(), filterString);
+        return Strings.CI.contains(getAddressString(), filterString);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/funds/withdrawal/WithdrawalListItem.java
@@ -31,6 +31,7 @@ import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Transaction;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import javafx.scene.control.Label;
 
@@ -134,10 +135,10 @@ class WithdrawalListItem implements FilterableListItem {
         if (filterString.isEmpty()) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getBalanceAsString(), filterString)) {
+        if (Strings.CI.contains(getBalanceAsString(), filterString)) {
             return true;
         }
-        return StringUtils.containsIgnoreCase(getAddressString(), filterString);
+        return Strings.CI.contains(getAddressString(), filterString);
 
     }
 }

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/bsqswaps/UnconfirmedBsqSwapsListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/bsqswaps/UnconfirmedBsqSwapsListItem.java
@@ -40,7 +40,7 @@ import bisq.core.util.coin.CoinFormatter;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.TransactionConfidence;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import javafx.scene.control.Tooltip;
 
@@ -173,31 +173,31 @@ class UnconfirmedBsqSwapsListItem implements FilterableListItem {
         if (filterString.isEmpty()) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getDateAsString(), filterString)) {
+        if (Strings.CI.contains(getDateAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getMarketLabel(), filterString)) {
+        if (Strings.CI.contains(getMarketLabel(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getPriceAsString(), filterString)) {
+        if (Strings.CI.contains(getPriceAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getVolumeAsString(), filterString)) {
+        if (Strings.CI.contains(getVolumeAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getAmountAsString(), filterString)) {
+        if (Strings.CI.contains(getAmountAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getTradeFeeAsString(), filterString)) {
+        if (Strings.CI.contains(getTradeFeeAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getTxFeeAsString(), filterString)) {
+        if (Strings.CI.contains(getTxFeeAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(String.valueOf(getConfidence()), filterString)) {
+        if (Strings.CI.contains(String.valueOf(getConfidence()), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getDirectionLabel(), filterString)) {
+        if (Strings.CI.contains(getDirectionLabel(), filterString)) {
             return true;
         }
         if (FilteringUtils.match(getBsqSwapTrade(), filterString)) {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/closedtrades/ClosedTradesListItem.java
@@ -33,7 +33,7 @@ import bisq.core.trade.model.bsq_swap.BsqSwapTrade;
 
 import org.bitcoinj.core.Coin;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import java.util.Date;
 
@@ -137,40 +137,40 @@ public class ClosedTradesListItem implements FilterableListItem {
         if (filterString.isEmpty()) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getDateAsString(), filterString)) {
+        if (Strings.CI.contains(getDateAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getMarketLabel(), filterString)) {
+        if (Strings.CI.contains(getMarketLabel(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getPriceAsString(), filterString)) {
+        if (Strings.CI.contains(getPriceAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getPriceDeviationAsString(), filterString)) {
+        if (Strings.CI.contains(getPriceDeviationAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getVolumeAsString(true), filterString)) {
+        if (Strings.CI.contains(getVolumeAsString(true), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getAmountAsString(), filterString)) {
+        if (Strings.CI.contains(getAmountAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getTradeFeeAsString(true), filterString)) {
+        if (Strings.CI.contains(getTradeFeeAsString(true), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getTxFeeAsString(), filterString)) {
+        if (Strings.CI.contains(getTxFeeAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getBuyerSecurityDepositAsString(), filterString)) {
+        if (Strings.CI.contains(getBuyerSecurityDepositAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getSellerSecurityDepositAsString(), filterString)) {
+        if (Strings.CI.contains(getSellerSecurityDepositAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getState(), filterString)) {
+        if (Strings.CI.contains(getState(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getDirectionLabel(), filterString)) {
+        if (Strings.CI.contains(getDirectionLabel(), filterString)) {
             return true;
         }
         if (FilteringUtils.match(getTradable().getOffer(), filterString)) {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/failedtrades/FailedTradesListItem.java
@@ -31,7 +31,7 @@ import bisq.core.util.FormattingUtils;
 import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.CoinFormatter;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import lombok.Getter;
 
@@ -82,22 +82,22 @@ class FailedTradesListItem implements FilterableListItem {
         if (filterString.isEmpty()) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getDateAsString(), filterString)) {
+        if (Strings.CI.contains(getDateAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getMarketLabel(), filterString)) {
+        if (Strings.CI.contains(getMarketLabel(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getPriceAsString(), filterString)) {
+        if (Strings.CI.contains(getPriceAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getVolumeAsString(), filterString)) {
+        if (Strings.CI.contains(getVolumeAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getAmountAsString(), filterString)) {
+        if (Strings.CI.contains(getAmountAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getDirectionLabel(), filterString)) {
+        if (Strings.CI.contains(getDirectionLabel(), filterString)) {
             return true;
         }
         if (FilteringUtils.match(getTrade().getOffer(), filterString)) {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/openoffer/OpenOfferListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/openoffer/OpenOfferListItem.java
@@ -34,7 +34,7 @@ import bisq.core.util.VolumeUtil;
 import bisq.core.util.coin.BsqFormatter;
 import bisq.core.util.coin.CoinFormatter;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import lombok.Getter;
 
@@ -141,28 +141,28 @@ class OpenOfferListItem implements FilterableListItem {
         if (filterString.isEmpty()) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getDateAsString(), filterString)) {
+        if (Strings.CI.contains(getDateAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getMarketDescription(), filterString)) {
+        if (Strings.CI.contains(getMarketDescription(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getPriceAsString(), filterString)) {
+        if (Strings.CI.contains(getPriceAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getPriceDeviationAsString(), filterString)) {
+        if (Strings.CI.contains(getPriceDeviationAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getPaymentMethodAsString(), filterString)) {
+        if (Strings.CI.contains(getPaymentMethodAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getVolumeAsString(), filterString)) {
+        if (Strings.CI.contains(getVolumeAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getAmountAsString(), filterString)) {
+        if (Strings.CI.contains(getAmountAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getDirectionLabel(), filterString)) {
+        if (Strings.CI.contains(getDirectionLabel(), filterString)) {
             return true;
         }
         return FilteringUtils.match(getOffer(), filterString);

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesListItem.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesListItem.java
@@ -24,7 +24,7 @@ import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.util.FormattingUtils;
 import bisq.core.util.coin.CoinFormatter;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,18 +73,18 @@ public class PendingTradesListItem implements FilterableListItem {
         if (filterString.isEmpty()) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getTrade().getId(), filterString)) {
+        if (Strings.CI.contains(getTrade().getId(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getAmountAsString(), filterString)) {
+        if (Strings.CI.contains(getAmountAsString(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getPaymentMethod(), filterString)) {
+        if (Strings.CI.contains(getPaymentMethod(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(getMarketDescription(), filterString)) {
+        if (Strings.CI.contains(getMarketDescription(), filterString)) {
             return true;
         }
-        return StringUtils.containsIgnoreCase(getPriceAsString(), filterString);
+        return Strings.CI.contains(getPriceAsString(), filterString);
     }
 }

--- a/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
+++ b/desktop/src/main/java/bisq/desktop/util/DisplayUtils.java
@@ -22,6 +22,7 @@ import bisq.common.crypto.PubKeyRing;
 import org.bitcoinj.core.Coin;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 
 import java.text.DateFormat;
@@ -109,7 +110,7 @@ public class DisplayUtils {
         String day = Res.get("time.day").toLowerCase();
         String days = Res.get("time.days");
         String format = " d' " + days + "'";
-        return StringUtils.strip(StringUtils.replaceOnce(DurationFormatUtils.formatDuration(durationMillis, format), " 1 " + days, " 1 " + day));
+        return StringUtils.strip(Strings.CS.replaceOnce(DurationFormatUtils.formatDuration(durationMillis, format), " 1 " + days, " 1 " + day));
     }
 
     public static String booleanToYesNo(boolean value) {

--- a/desktop/src/main/java/bisq/desktop/util/filtering/FilteringUtils.java
+++ b/desktop/src/main/java/bisq/desktop/util/filtering/FilteringUtils.java
@@ -22,37 +22,37 @@ import bisq.core.trade.model.bisq_v1.Contract;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.model.bsq_swap.BsqSwapTrade;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 public class FilteringUtils {
     public static boolean match(Offer offer, String filterString) {
-        if (StringUtils.containsIgnoreCase(offer.getId(), filterString)) {
+        if (Strings.CI.contains(offer.getId(), filterString)) {
             return true;
         }
-        if (StringUtils.containsIgnoreCase(offer.getPaymentMethod().getDisplayString(), filterString)) {
+        if (Strings.CI.contains(offer.getPaymentMethod().getDisplayString(), filterString)) {
             return true;
         }
-        return offer.getOfferFeePaymentTxId() != null && StringUtils.containsIgnoreCase(offer.getOfferFeePaymentTxId(), filterString);
+        return offer.getOfferFeePaymentTxId() != null && Strings.CI.contains(offer.getOfferFeePaymentTxId(), filterString);
     }
 
     public static boolean match(BsqSwapTrade bsqSwapTrade, String filterString) {
-        if (bsqSwapTrade.getTxId() != null && StringUtils.containsIgnoreCase(bsqSwapTrade.getTxId(), filterString)) {
+        if (bsqSwapTrade.getTxId() != null && Strings.CI.contains(bsqSwapTrade.getTxId(), filterString)) {
             return true;
         }
-        return StringUtils.containsIgnoreCase(bsqSwapTrade.getTradingPeerNodeAddress().getFullAddress(), filterString);
+        return Strings.CI.contains(bsqSwapTrade.getTradingPeerNodeAddress().getFullAddress(), filterString);
     }
 
     public static boolean match(Trade trade, String filterString) {
         if (trade == null) {
             return false;
         }
-        if (trade.getTakerFeeTxId() != null && StringUtils.containsIgnoreCase(trade.getTakerFeeTxId(), filterString)) {
+        if (trade.getTakerFeeTxId() != null && Strings.CI.contains(trade.getTakerFeeTxId(), filterString)) {
             return true;
         }
-        if (trade.getDepositTxId() != null && StringUtils.containsIgnoreCase(trade.getDepositTxId(), filterString)) {
+        if (trade.getDepositTxId() != null && Strings.CI.contains(trade.getDepositTxId(), filterString)) {
             return true;
         }
-        if (trade.getPayoutTxId() != null && StringUtils.containsIgnoreCase(trade.getPayoutTxId(), filterString)) {
+        if (trade.getPayoutTxId() != null && Strings.CI.contains(trade.getPayoutTxId(), filterString)) {
             return true;
         }
         return match(trade.getContract(), filterString);
@@ -64,12 +64,12 @@ public class FilteringUtils {
         boolean matchesBuyersPaymentAccountData = false;
         boolean matchesSellersPaymentAccountData = false;
         if (contract != null) {
-            isBuyerOnion = StringUtils.containsIgnoreCase(contract.getBuyerNodeAddress().getFullAddress(), filterString);
-            isSellerOnion = StringUtils.containsIgnoreCase(contract.getSellerNodeAddress().getFullAddress(), filterString);
+            isBuyerOnion = Strings.CI.contains(contract.getBuyerNodeAddress().getFullAddress(), filterString);
+            isSellerOnion = Strings.CI.contains(contract.getSellerNodeAddress().getFullAddress(), filterString);
             matchesBuyersPaymentAccountData = contract.getBuyerPaymentAccountPayload() != null &&
-                    StringUtils.containsIgnoreCase(contract.getBuyerPaymentAccountPayload().getPaymentDetails(), filterString);
+                    Strings.CI.contains(contract.getBuyerPaymentAccountPayload().getPaymentDetails(), filterString);
             matchesSellersPaymentAccountData = contract.getSellerPaymentAccountPayload() != null &&
-                    StringUtils.containsIgnoreCase(contract.getSellerPaymentAccountPayload().getPaymentDetails(), filterString);
+                    Strings.CI.contains(contract.getSellerPaymentAccountPayload().getPaymentDetails(), filterString);
         }
         return isBuyerOnion || isSellerOnion ||
                 matchesBuyersPaymentAccountData || matchesSellersPaymentAccountData;

--- a/desktop/src/main/java/bisq/desktop/util/validation/AccountNrValidator.java
+++ b/desktop/src/main/java/bisq/desktop/util/validation/AccountNrValidator.java
@@ -21,6 +21,7 @@ import bisq.core.locale.BankUtil;
 import bisq.core.locale.Res;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 
 public final class AccountNrValidator extends BankValidator {
     public AccountNrValidator(String countryCode) {
@@ -89,8 +90,8 @@ public final class AccountNrValidator extends BankValidator {
                     // MOD11 with weights 2,3,4,5,6,7,2,3,4,5 right to left.
                     // First remove whitespace and periods.  Normal formatting is:
                     // 1234.56.78903
-                    input2 = StringUtils.remove(input, " ");
-                    input2 = StringUtils.remove(input2, ".");
+                    input2 = Strings.CS.remove(input, " ");
+                    input2 = Strings.CS.remove(input2, ".");
                     // 11 digits, numbers only
                     if (input2.length() != length || !StringUtils.isNumeric(input2))
                         return new ValidationResult(false, Res.get("validation.sortCodeNumber", getLabel(), length));


### PR DESCRIPTION
- [Replace StringUtils with Strings.CI for contains](https://github.com/bisq-network/bisq/commit/2c969dc1f89d1c49ad8636571d23f8e3089429fe)
  - The StringUtils.containsIgnoreCase method got deprecated. This commit swaps it out for Strings.CI.contains, which is its direct replacement.
- [Replace StringUtils with Strings.CS for replaceOnce](https://github.com/bisq-network/bisq/commit/1565ebdd14fc3a2af1554b713ab8993bdf4db6ab)
  - The `StringUtils.replaceOnce` method got deprecated. This commit swaps it out for `Strings.CS.replaceOnce`, which is its direct replacement.
- [Replace StringUtils with Strings.CS for remove](https://github.com/bisq-network/bisq/commit/5a52a2f4e39f1e5c577c6e7cd8cde6e9f2074a83)
  - The `StringUtils.remove` method got deprecated. This commit
swaps it out for `Strings.CS.remove`, which is its direct
replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of case-insensitive filtering across search, trading, funds, and portfolio lists.
  * Preserved exact account-age formatting and Norwegian account-number validation behavior.
  * Ensured account-number normalization continues to remove spaces and periods correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->