### PR TITLE
Suppress deprecation warnings for Verse

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/VerseForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/VerseForm.java
@@ -37,8 +37,10 @@ import static bisq.desktop.util.FormBuilder.addCompactTopLabelTextField;
 import static bisq.desktop.util.FormBuilder.addCompactTopLabelTextFieldWithCopyIcon;
 
 public class VerseForm extends PaymentMethodForm {
+    @SuppressWarnings("deprecation")
     private final VerseAccount account;
 
+    @SuppressWarnings("deprecation")
     public static int addFormForBuyer(GridPane gridPane, int gridRow,
                                       PaymentAccountPayload paymentAccountPayload) {
         addCompactTopLabelTextFieldWithCopyIcon(gridPane, ++gridRow, Res.get("payment.account.userName"),
@@ -46,9 +48,10 @@ public class VerseForm extends PaymentMethodForm {
         return gridRow;
     }
 
+    @SuppressWarnings("deprecation")
     public VerseForm(PaymentAccount paymentAccount, AccountAgeWitnessService accountAgeWitnessService,
-                      InputValidator inputValidator, GridPane gridPane,
-                      int gridRow, CoinFormatter formatter) {
+                     InputValidator inputValidator, GridPane gridPane,
+                     int gridRow, CoinFormatter formatter) {
         super(paymentAccount, accountAgeWitnessService, inputValidator, gridPane, gridRow, formatter);
         this.account = (VerseAccount) paymentAccount;
     }

--- a/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsView.java
+++ b/desktop/src/main/java/bisq/desktop/main/account/content/fiataccounts/FiatAccountsView.java
@@ -455,7 +455,7 @@ public class FiatAccountsView extends PaymentAccountsView<GridPane, FiatAccounts
         paymentMethodComboBox = FormBuilder.addComboBox(root, gridRow, Res.get("shared.selectPaymentMethod"), Layout.FIRST_ROW_AND_GROUP_DISTANCE);
         paymentMethodComboBox.setVisibleRowCount(11);
         paymentMethodComboBox.setPrefWidth(250);
-        List<PaymentMethod> list = PaymentMethod.getPaymentMethods().stream()
+        @SuppressWarnings("deprecation") List<PaymentMethod> list = PaymentMethod.getPaymentMethods().stream()
                 .filter(PaymentMethod::isFiat)
                 .filter(paymentMethod -> !paymentMethod.getId().equals(PaymentMethod.VERSE_ID)) // Verse not existing anymore
                 .sorted()


### PR DESCRIPTION
Verse was deprecated and removed as a payment method because the service shut down. This change suppresses the resulting deprecation warnings to keep the build output clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deprecation handling for payment account components.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->