### PR TITLE
common: Migrate to secure() RandomStringUtils API

### DIFF
--- a/common/src/test/java/bisq/common/crypto/HashCashServiceTest.java
+++ b/common/src/test/java/bisq/common/crypto/HashCashServiceTest.java
@@ -72,7 +72,7 @@ public class HashCashServiceTest {
     private void run(int log2Difficulty, StringBuilder stringBuilder) throws ExecutionException, InterruptedException {
         double difficulty = Math.scalb(1.0, log2Difficulty);
         int numTokens = 1000;
-        byte[] payload = RandomStringUtils.random(50, true, true).getBytes(StandardCharsets.UTF_8);
+        byte[] payload = RandomStringUtils.secure().next(50, true, true).getBytes(StandardCharsets.UTF_8);
         long ts = System.currentTimeMillis();
         List<ProofOfWork> tokens = new ArrayList<>();
         for (int i = 0; i < numTokens; i++) {


### PR DESCRIPTION
The randomAlphabetic and randomNumeric methods in RandomStringUtils are deprecated and now require developers to explicitly choose a generator: secure(), secureStrong(), or insecure().

This commit updates the HashCashServiceTest's test payload generation to use secure().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test payload generation by using a cryptographically secure random source.
  * No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->