### PR TITLE
Rebased detect dead deposit tx

### DIFF
--- a/core/src/main/java/bisq/core/provider/mempool/FeeValidationStatus.java
+++ b/core/src/main/java/bisq/core/provider/mempool/FeeValidationStatus.java
@@ -25,6 +25,7 @@ public enum FeeValidationStatus {
     ACK_BSQ_TX_IS_NEW("fee.validation.ack.bsqTxIsNew"),
     ACK_CHECK_BYPASSED("fee.validation.ack.checkBypassed"),
     NACK_BTC_TX_NOT_FOUND("fee.validation.error.btcTxNotFound"),
+    NACK_TX_LOOKUP_UNREACHABLE("fee.validation.error.txLookupUnreachable"),
     NACK_BSQ_FEE_NOT_FOUND("fee.validation.error.bsqTxNotFound"),
     NACK_MAKER_FEE_TOO_LOW("fee.validation.error.makerFeeTooLow"),
     NACK_TAKER_FEE_TOO_LOW("fee.validation.error.takerFeeTooLow"),

--- a/core/src/main/java/bisq/core/provider/mempool/MempoolService.java
+++ b/core/src/main/java/bisq/core/provider/mempool/MempoolService.java
@@ -29,6 +29,7 @@ import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.user.Preferences;
 
 import bisq.network.Socks5ProxyProvider;
+import bisq.network.http.HttpException;
 
 import bisq.common.UserThread;
 import bisq.common.config.Config;
@@ -49,6 +50,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -60,6 +62,9 @@ import javax.annotation.Nullable;
 @Slf4j
 @Singleton
 public class MempoolService {
+    // Upper bound for the cause chain walk in isTxUnknownResponse.
+    private static final int MAX_CAUSE_CHAIN_DEPTH = 20;
+
     private final Socks5ProxyProvider socks5ProxyProvider;
     private final Config config;
     private final Preferences preferences;
@@ -137,9 +142,7 @@ public class MempoolService {
             return;
         }
         MempoolRequest mempoolRequest = new MempoolRequest(preferences, socks5ProxyProvider, config.allowLanForHttpRequests, config.allowClearnetHttpRequests);
-        SettableFuture<String> future = SettableFuture.create();
-        Futures.addCallback(future, callbackForTxRequest(mempoolRequest, txValidator, resultHandler), MoreExecutors.directExecutor());
-        mempoolRequest.getTxStatus(future, txId);
+        checkTxIsConfirmed(mempoolRequest, txValidator, new AtomicBoolean(true), resultHandler);
     }
 
     public CompletableFuture<String> requestTxAsHex(String txId) {
@@ -163,6 +166,22 @@ public class MempoolService {
         SettableFuture<String> future = SettableFuture.create();
         Futures.addCallback(future, callbackForTakerTxValidation(mempoolRequest, txValidator, resultHandler), MoreExecutors.directExecutor());
         mempoolRequest.getTxStatus(future, txValidator.getTxId());
+    }
+
+    private void checkTxIsConfirmed(MempoolRequest mempoolRequest,
+                                    TxValidator txValidator,
+                                    AtomicBoolean everyProviderAnswered404,
+                                    Consumer<TxValidator> resultHandler) {
+        SettableFuture<String> future = SettableFuture.create();
+        Futures.addCallback(future, callbackForTxRequest(mempoolRequest, txValidator, everyProviderAnswered404, resultHandler),
+                MoreExecutors.directExecutor());
+        try {
+            mempoolRequest.getTxStatus(future, txValidator.getTxId());
+        } catch (RuntimeException e) {
+            // The request could not even be dispatched. Feed that through the callback so the
+            // outstanding request accounting stays balanced and the caller still gets a result.
+            future.setException(e);
+        }
     }
 
     private FutureCallback<String> callbackForMakerTxValidation(MempoolRequest theRequest,
@@ -235,6 +254,7 @@ public class MempoolService {
 
     private FutureCallback<String> callbackForTxRequest(MempoolRequest theRequest,
                                                         TxValidator txValidator,
+                                                        AtomicBoolean everyProviderAnswered404,
                                                         Consumer<TxValidator> resultHandler) {
         outstandingRequests++;
         FutureCallback<String> myCallback = new FutureCallback<>() {
@@ -252,12 +272,39 @@ public class MempoolService {
                 log.warn("onFailure - {}", throwable.toString());
                 UserThread.execute(() -> {
                     outstandingRequests--;
-                    resultHandler.accept(txValidator.endResult(FeeValidationStatus.NACK_BTC_TX_NOT_FOUND));
+                    // Only a definitive "tx unknown" (HTTP 404) answer tells us anything about the tx. Any
+                    // other failure is a transport problem, so we must not conclude the tx does not exist.
+                    if (!isTxUnknownResponse(throwable)) {
+                        everyProviderAnswered404.set(false);
+                    }
+                    if (theRequest.switchToAnotherProvider()) {
+                        checkTxIsConfirmed(theRequest, txValidator, everyProviderAnswered404, resultHandler);
+                    } else {
+                        // exhausted all providers, let user know of failure
+                        resultHandler.accept(txValidator.endResult(everyProviderAnswered404.get() ?
+                                FeeValidationStatus.NACK_BTC_TX_NOT_FOUND :
+                                FeeValidationStatus.NACK_TX_LOOKUP_UNREACHABLE));
+                    }
                 });
 
             }
         };
         return myCallback;
+    }
+
+    // The block explorers answer with HTTP 404 if they do not know the tx. The HttpException carrying that
+    // response code is wrapped into an IOException by the http client, so we walk the cause chain. The
+    // depth is bounded so that a self referencing cause cannot spin the calling thread. Giving up early
+    // reports the failure as a transport problem, which is the safe direction.
+    @VisibleForTesting
+    static boolean isTxUnknownResponse(Throwable throwable) {
+        Throwable candidate = throwable;
+        for (int depth = 0; candidate != null && depth < MAX_CAUSE_CHAIN_DEPTH; candidate = candidate.getCause(), depth++) {
+            if (candidate instanceof HttpException && ((HttpException) candidate).getResponseCode() == 404) {
+                return true;
+            }
+        }
+        return false;
     }
 
     // /////////////////////////////

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -750,7 +750,7 @@ portfolio.pending.unconfirmedTooLong=Security deposit transaction on trade {0} i
   ● Do an SPV resync. [HYPERLINK:https://bisq.wiki/Resyncing_SPV_file]\n\n\
   Contact Bisq support [HYPERLINK:https://bisq.chat] if you have doubts or the issue persists.
 
-portfolio.pending.depositTxDead=The deposit transaction of trade {0} has been unconfirmed for {1} hours and is unknown to all block explorers.\n\n\
+portfolio.pending.depositTxDead=The deposit transaction of trade {0} has been unconfirmed for {1} hours and is unknown to all configured block explorers.\n\n\
   This is what it looks like when an input of the deposit transaction has been spent by another transaction, \
   in which case nodes will neither relay nor mine it. A transaction which was only dropped from the mempools \
   looks the same from here, but that one may still be confirmed later.\n\n\
@@ -1112,7 +1112,7 @@ portfolio.pending.failedTrade.missingDepositTx=The deposit transaction (the 2-of
   appropriate for you to consider making a reimbursement request please see here \
   [HYPERLINK:https://bisq.wiki/Failed_Trades_-_Reimbursement_of_Trade_Fees_and_Miner_Fees]\n\n\
   Feel free to move this trade to failed trades.
-portfolio.pending.failedTrade.depositTxDead=The deposit transaction is unknown to all block explorers, so most likely it can no longer be confirmed.
+portfolio.pending.failedTrade.depositTxDead=The deposit transaction is unknown to all configured block explorers, so most likely it can no longer be confirmed.
 portfolio.pending.failedTrade.buyer.existingDepositTxButMissingDelayedPayoutTx=The delayed payout transaction is missing, \
   but funds have been locked in the deposit transaction.\n\n\
   Please do NOT send the fiat or altcoin payment to the BTC seller, because without the delayed payout tx, arbitration \
@@ -1154,18 +1154,18 @@ portfolio.pending.failedTrade.txChainValid.moveToFailed=The trade protocol encou
   You cannot open mediation or arbitration from the failed trades view, but you can move a failed trade back to the open \
   trades screen any time.
 portfolio.pending.failedTrade.depositTxDead.moveToFailed=The trade protocol encountered some problems.\n\n{0}\n\n\
-  The deposit transaction was re-checked just now and is still unknown to all block explorers. That verdict comes \
+  The deposit transaction was re-checked just now and is still unknown to all configured block explorers. That verdict comes \
   from external services, and a transaction which was only dropped from the mempools can still confirm later. \
   Nothing is locked in the trade while the deposit is unconfirmed.\n\n\
   Do you want to move the trade to failed trades?\n\n\
   You cannot open mediation or arbitration from the failed trades view, but you can move a failed trade back to the open \
   trades screen any time, for example if the deposit transaction turns out to be alive after all.
-portfolio.pending.failedTrade.depositTxDead.recheckTooRecent=The deposit transaction is still unknown to all block explorers, \
+portfolio.pending.failedTrade.depositTxDead.recheckTooRecent=The deposit transaction is still unknown to all configured block explorers, \
   but the first such answer arrived less than {0} minutes ago. A transaction broadcast a moment ago may simply not have \
   reached the explorers yet, so please try again later.
 portfolio.pending.failedTrade.depositTxDead.recheckFound=A block explorer now returned a status for the deposit transaction, \
   so it is not gone from the network. The trade stays in open trades.
-portfolio.pending.failedTrade.depositTxDead.recheckUnreachable=Could not reach any block explorer to re-check the deposit \
+portfolio.pending.failedTrade.depositTxDead.recheckUnreachable=Could not reach any configured block explorer to re-check the deposit \
   transaction. The trade stays in open trades. Please try again later.
 portfolio.pending.failedTrade.moveTradeToFailedIcon.tooltip=Move trade to failed trades
 portfolio.pending.failedTrade.warningIcon.tooltip=Click to open details about the issues of this trade

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -754,7 +754,8 @@ portfolio.pending.depositTxDead=The trade {0} started {1} hours ago, its deposit
   This is what it looks like when an input of the deposit transaction has been spent by another transaction, \
   in which case nodes will neither relay nor mine it. A transaction which was only dropped from the mempools \
   looks the same from here, but that one may still be confirmed later.\n\n\
-  Nothing is locked in the trade for as long as the deposit is unconfirmed. You can try an SPV resync to update your wallet. \
+  No trade funds are locked in the deposit while it is unconfirmed, but the wallet inputs funding it stay reserved \
+  until it confirms or is removed. You can try an SPV resync to update your wallet. \
   If the deposit transaction stays unknown, you can move the trade to failed trades to remove it, and move it back \
   from there if it turns out to be alive after all.
 
@@ -1156,7 +1157,8 @@ portfolio.pending.failedTrade.txChainValid.moveToFailed=The trade protocol encou
 portfolio.pending.failedTrade.depositTxDead.moveToFailed=The trade protocol encountered some problems.\n\n{0}\n\n\
   The deposit transaction was re-checked just now and is still unknown to all configured block explorers. That verdict comes \
   from external services, and a transaction which was only dropped from the mempools can still confirm later. \
-  Nothing is locked in the trade while the deposit is unconfirmed.\n\n\
+  No trade funds are locked in the deposit while it is unconfirmed, but the wallet inputs funding it stay reserved \
+  until it confirms or is removed.\n\n\
   Do you want to move the trade to failed trades?\n\n\
   You cannot open mediation or arbitration from the failed trades view, but you can move a failed trade back to the open \
   trades screen any time, for example if the deposit transaction turns out to be alive after all.

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -750,6 +750,14 @@ portfolio.pending.unconfirmedTooLong=Security deposit transaction on trade {0} i
   ● Do an SPV resync. [HYPERLINK:https://bisq.wiki/Resyncing_SPV_file]\n\n\
   Contact Bisq support [HYPERLINK:https://bisq.chat] if you have doubts or the issue persists.
 
+portfolio.pending.depositTxDead=The deposit transaction of trade {0} has been unconfirmed for {1} hours and is unknown to all block explorers.\n\n\
+  This is what it looks like when an input of the deposit transaction has been spent by another transaction, \
+  in which case nodes will neither relay nor mine it. A transaction which was only dropped from the mempools \
+  looks the same from here, but that one may still be confirmed later.\n\n\
+  Nothing is locked in the trade for as long as the deposit is unconfirmed. You can try an SPV resync to update your wallet. \
+  If the deposit transaction stays unknown, you can move the trade to failed trades to remove it, and move it back \
+  from there if it turns out to be alive after all.
+
 portfolio.pending.step1.waitForConf=Wait for blockchain confirmation
 portfolio.pending.step2_buyer.startPayment=Start payment
 portfolio.pending.step2_seller.waitPaymentStarted=Wait until payment has started
@@ -1104,6 +1112,7 @@ portfolio.pending.failedTrade.missingDepositTx=The deposit transaction (the 2-of
   appropriate for you to consider making a reimbursement request please see here \
   [HYPERLINK:https://bisq.wiki/Failed_Trades_-_Reimbursement_of_Trade_Fees_and_Miner_Fees]\n\n\
   Feel free to move this trade to failed trades.
+portfolio.pending.failedTrade.depositTxDead=The deposit transaction is unknown to all block explorers, so most likely it can no longer be confirmed.
 portfolio.pending.failedTrade.buyer.existingDepositTxButMissingDelayedPayoutTx=The delayed payout transaction is missing, \
   but funds have been locked in the deposit transaction.\n\n\
   Please do NOT send the fiat or altcoin payment to the BTC seller, because without the delayed payout tx, arbitration \
@@ -3795,6 +3804,8 @@ fee.validation.ack.bsqTxIsNew=BSQ tx new/unconfirmed, fee assumed OK
 fee.validation.ack.checkBypassed=Fee check bypassed
 # suppress inspection "UnusedProperty"
 fee.validation.error.btcTxNotFound=BTC fee tx not found
+# suppress inspection "UnusedProperty"
+fee.validation.error.txLookupUnreachable=Could not reach a block explorer to look up the transaction
 # suppress inspection "UnusedProperty"
 fee.validation.error.bsqTxNotFound=BSQ fee tx not found
 # suppress inspection "UnusedProperty"

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -750,7 +750,7 @@ portfolio.pending.unconfirmedTooLong=Security deposit transaction on trade {0} i
   ● Do an SPV resync. [HYPERLINK:https://bisq.wiki/Resyncing_SPV_file]\n\n\
   Contact Bisq support [HYPERLINK:https://bisq.chat] if you have doubts or the issue persists.
 
-portfolio.pending.depositTxDead=The deposit transaction of trade {0} has been unconfirmed for {1} hours and is unknown to all configured block explorers.\n\n\
+portfolio.pending.depositTxDead=The trade {0} started {1} hours ago, its deposit transaction is still unconfirmed and it is unknown to all configured block explorers.\n\n\
   This is what it looks like when an input of the deposit transaction has been spent by another transaction, \
   in which case nodes will neither relay nor mine it. A transaction which was only dropped from the mempools \
   looks the same from here, but that one may still be confirmed later.\n\n\

--- a/core/src/main/resources/i18n/displayStrings.properties
+++ b/core/src/main/resources/i18n/displayStrings.properties
@@ -1153,6 +1153,20 @@ portfolio.pending.failedTrade.txChainValid.moveToFailed=The trade protocol encou
   Do you want to move the trade to failed trades?\n\n\
   You cannot open mediation or arbitration from the failed trades view, but you can move a failed trade back to the open \
   trades screen any time.
+portfolio.pending.failedTrade.depositTxDead.moveToFailed=The trade protocol encountered some problems.\n\n{0}\n\n\
+  The deposit transaction was re-checked just now and is still unknown to all block explorers. That verdict comes \
+  from external services, and a transaction which was only dropped from the mempools can still confirm later. \
+  Nothing is locked in the trade while the deposit is unconfirmed.\n\n\
+  Do you want to move the trade to failed trades?\n\n\
+  You cannot open mediation or arbitration from the failed trades view, but you can move a failed trade back to the open \
+  trades screen any time, for example if the deposit transaction turns out to be alive after all.
+portfolio.pending.failedTrade.depositTxDead.recheckTooRecent=The deposit transaction is still unknown to all block explorers, \
+  but the first such answer arrived less than {0} minutes ago. A transaction broadcast a moment ago may simply not have \
+  reached the explorers yet, so please try again later.
+portfolio.pending.failedTrade.depositTxDead.recheckFound=A block explorer now returned a status for the deposit transaction, \
+  so it is not gone from the network. The trade stays in open trades.
+portfolio.pending.failedTrade.depositTxDead.recheckUnreachable=Could not reach any block explorer to re-check the deposit \
+  transaction. The trade stays in open trades. Please try again later.
 portfolio.pending.failedTrade.moveTradeToFailedIcon.tooltip=Move trade to failed trades
 portfolio.pending.failedTrade.warningIcon.tooltip=Click to open details about the issues of this trade
 portfolio.failed.revertToPending.popup=Do you want to move this trade to open trades?

--- a/core/src/test/java/bisq/core/provider/mempool/MempoolServiceTest.java
+++ b/core/src/test/java/bisq/core/provider/mempool/MempoolServiceTest.java
@@ -26,8 +26,13 @@ import bisq.core.filter.FilterPolicyService;
 import bisq.core.user.Preferences;
 
 import bisq.network.Socks5ProxyProvider;
+import bisq.network.http.HttpException;
 
 import bisq.common.config.Config;
+
+import java.io.IOException;
+
+import java.net.SocketTimeoutException;
 
 import java.util.List;
 import java.util.Map;
@@ -85,6 +90,52 @@ class MempoolServiceTest {
                 mock(DaoStateService.class),
                 burningManAddressListService,
                 burningManPresentationService);
+    }
+
+    @Test
+    void isTxUnknownResponseDetectsWrapped404() {
+        // The shape the http client actually produces: HttpException rewrapped into an IOException.
+        Throwable wrapped = new IOException("Direct request failed", new HttpException("Transaction not found", 404));
+
+        assertTrue(MempoolService.isTxUnknownResponse(wrapped));
+    }
+
+    @Test
+    void isTxUnknownResponseDetects404AtAnyDepth() {
+        Throwable nested = new RuntimeException("outer",
+                new IOException("middle", new HttpException("Transaction not found", 404)));
+
+        assertTrue(MempoolService.isTxUnknownResponse(nested));
+    }
+
+    @Test
+    void isTxUnknownResponseRejectsTransportFailure() {
+        // No HttpException in the chain means we never got an answer, so the tx state stays unknown.
+        Throwable connectionFailure = new IOException("Request via SOCKS proxy failed", new SocketTimeoutException());
+
+        assertFalse(MempoolService.isTxUnknownResponse(connectionFailure));
+    }
+
+    @Test
+    void isTxUnknownResponseRejectsOtherResponseCodes() {
+        Throwable serverError = new IOException("Request failed", new HttpException("Request failed", 500));
+
+        assertFalse(MempoolService.isTxUnknownResponse(serverError));
+    }
+
+    @Test
+    void isTxUnknownResponseHandlesNull() {
+        assertFalse(MempoolService.isTxUnknownResponse(null));
+    }
+
+    @Test
+    void isTxUnknownResponseTerminatesOnCyclicCauseChain() {
+        // A cyclic chain must not spin the calling thread, and must not be read as a 404.
+        Throwable first = new IOException("first");
+        Throwable second = new IOException("second", first);
+        first.initCause(second);
+
+        assertFalse(MempoolService.isTxUnknownResponse(first));
     }
 
     private static BurningManAddressList addressList(String network) {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
@@ -101,12 +101,14 @@ import javafx.beans.value.ChangeListener;
 import javafx.event.EventHandler;
 
 import javafx.collections.ListChangeListener;
+import javafx.collections.MapChangeListener;
 import javafx.collections.ObservableList;
-import javafx.collections.SetChangeListener;
 import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 
 import javafx.util.Callback;
+
+import java.time.Instant;
 
 import java.util.Comparator;
 import java.util.HashMap;
@@ -144,7 +146,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
     private Subscription selectedItemSubscription;
     private Stage chatPopupStage;
     private ListChangeListener<PendingTradesListItem> tradesListChangeListener;
-    private SetChangeListener<String> deadDepositTradesListener;
+    private MapChangeListener<String, Instant> deadDepositTradesListener;
     private final Map<String, Long> newChatMessagesByTradeMap = new HashMap<>();
     private String tradeIdOfOpenChat;
     private double chatPopupStageXPosition = -1;
@@ -296,7 +298,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
         filterBox.activate();
 
         updateMoveTradeToFailedColumnState();
-        model.getDeadDepositTradeIds().addListener(deadDepositTradesListener);
+        model.getDeadDepositUnknownSince().addListener(deadDepositTradesListener);
 
         scene = root.getScene();
         if (scene != null) {
@@ -358,7 +360,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
         removeSelectedSubView();
 
         model.dataModel.list.removeListener(tradesListChangeListener);
-        model.getDeadDepositTradeIds().removeListener(deadDepositTradesListener);
+        model.getDeadDepositUnknownSince().removeListener(deadDepositTradesListener);
 
         if (scene != null)
             scene.removeEventHandler(KeyEvent.KEY_RELEASED, keyEventEventHandler);
@@ -385,11 +387,44 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
     }
 
     private void onMoveInvalidTradeToFailedTrades(Trade trade) {
+        if (model.isDepositTxProvenDead(trade)) {
+            // The verdict can be arbitrarily old by now; only a fresh unanimous not-found
+            // answer from the explorers authorizes the move.
+            model.recheckDeadDepositTx(trade, result -> {
+                switch (result) {
+                    case STILL_DEAD:
+                        showMoveInvalidTradeToFailedTradesPopup(trade,
+                                Res.get("portfolio.pending.failedTrade.depositTxDead.moveToFailed",
+                                        getInvalidTradeDetails(trade)));
+                        break;
+                    case TOO_RECENT:
+                        new Popup().information(
+                                Res.get("portfolio.pending.failedTrade.depositTxDead.recheckTooRecent",
+                                        PendingTradesViewModel.DEAD_DEPOSIT_SAFETY_INTERVAL.toMinutes())).show();
+                        break;
+                    case FOUND:
+                        new Popup().information(
+                                Res.get("portfolio.pending.failedTrade.depositTxDead.recheckFound")).show();
+                        break;
+                    case UNREACHABLE:
+                        new Popup().warning(
+                                Res.get("portfolio.pending.failedTrade.depositTxDead.recheckUnreachable")).show();
+                        break;
+                    default:
+                        log.error("Unhandled dead-deposit recheck result {}", result);
+                }
+            });
+            return;
+        }
         String msg = trade.isTxChainInvalid() ?
                 Res.get("portfolio.pending.failedTrade.txChainInvalid.moveToFailed",
                         getInvalidTradeDetails(trade)) :
                 Res.get("portfolio.pending.failedTrade.txChainValid.moveToFailed",
                         getInvalidTradeDetails(trade));
+        showMoveInvalidTradeToFailedTradesPopup(trade, msg);
+    }
+
+    private void showMoveInvalidTradeToFailedTradesPopup(Trade trade, String msg) {
         new Popup().width(900).attention(msg)
                 .onAction(() -> {
                     model.dataModel.onMoveInvalidTradeToFailedTrades(trade);

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesView.java
@@ -102,6 +102,7 @@ import javafx.event.EventHandler;
 
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
+import javafx.collections.SetChangeListener;
 import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 
@@ -143,6 +144,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
     private Subscription selectedItemSubscription;
     private Stage chatPopupStage;
     private ListChangeListener<PendingTradesListItem> tradesListChangeListener;
+    private SetChangeListener<String> deadDepositTradesListener;
     private final Map<String, Long> newChatMessagesByTradeMap = new HashMap<>();
     private String tradeIdOfOpenChat;
     private double chatPopupStageXPosition = -1;
@@ -273,6 +275,13 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
         };
 
         tradesListChangeListener = c -> onListChanged();
+
+        deadDepositTradesListener = c -> {
+            updateMoveTradeToFailedColumnState();
+            // The cells only redraw on a trade state change, which does not happen here, so the
+            // icons of an already visible column would otherwise stay empty until the view is reopened.
+            tableView.refresh();
+        };
     }
 
     @Override
@@ -287,6 +296,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
         filterBox.activate();
 
         updateMoveTradeToFailedColumnState();
+        model.getDeadDepositTradeIds().addListener(deadDepositTradesListener);
 
         scene = root.getScene();
         if (scene != null) {
@@ -348,6 +358,7 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
         removeSelectedSubView();
 
         model.dataModel.list.removeListener(tradesListChangeListener);
+        model.getDeadDepositTradeIds().removeListener(deadDepositTradesListener);
 
         if (scene != null)
             scene.removeEventHandler(KeyEvent.KEY_RELEASED, keyEventEventHandler);
@@ -369,7 +380,8 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
 
     private boolean isMaybeInvalidTrade(Trade trade) {
         return trade.hasErrorMessage() ||
-                (Trade.Phase.DEPOSIT_PUBLISHED.ordinal() <= trade.getTradePhase().ordinal() && trade.isTxChainInvalid());
+                (Trade.Phase.DEPOSIT_PUBLISHED.ordinal() <= trade.getTradePhase().ordinal() && trade.isTxChainInvalid()) ||
+                model.isDepositTxProvenDead(trade);
     }
 
     private void onMoveInvalidTradeToFailedTrades(Trade trade) {
@@ -412,6 +424,10 @@ public class PendingTradesView extends ActivatableViewAndModel<VBox, PendingTrad
 
         if (trade.getDepositTx() == null) {
             return Res.get("portfolio.pending.failedTrade.missingDepositTx");
+        }
+
+        if (model.isDepositTxProvenDead(trade)) {
+            return Res.get("portfolio.pending.failedTrade.depositTxDead");
         }
 
         if (trade.getDelayedPayoutTx() == null) {

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModel.java
@@ -35,6 +35,7 @@ import bisq.core.provider.mempool.FeeValidationStatus;
 import bisq.core.provider.mempool.MempoolService;
 import bisq.core.trade.ClosedTradableManager;
 import bisq.core.trade.bisq_v1.TradeUtil;
+import bisq.core.trade.model.bisq_v1.BuyerTrade;
 import bisq.core.trade.model.bisq_v1.Contract;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.user.DontShowAgainLookup;
@@ -52,6 +53,7 @@ import bisq.common.UserThread;
 import bisq.common.app.DevEnv;
 
 import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Transaction;
 
 import com.google.inject.Inject;
 
@@ -65,7 +67,7 @@ import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 
 import javafx.collections.FXCollections;
-import javafx.collections.ObservableSet;
+import javafx.collections.ObservableMap;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -74,6 +76,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import lombok.Getter;
@@ -129,10 +132,17 @@ public class PendingTradesViewModel extends ActivatableWithDataModel<PendingTrad
     private final ObjectProperty<MessageState> messageStateProperty = new SimpleObjectProperty<>(MessageState.UNDEFINED);
     private Subscription tradeStateSubscription;
     private Subscription messageStateSubscription;
-    // Transient, UI-local marker: trades whose deposit tx every block explorer reported as unknown.
-    // Not persisted, so a restart re-evaluates the situation from scratch. Observable so the view can
-    // reveal the "move to failed trades" column as soon as the (asynchronous) lookup comes back.
-    private final ObservableSet<String> deadDepositTradeIds = FXCollections.observableSet(new HashSet<>());
+    // Transient, UI-local marker: trades whose deposit tx every block explorer reported as unknown,
+    // keyed to the time of the first such observation. Not persisted, so a restart re-evaluates the
+    // situation from scratch. Observable so the view can reveal the "move to failed trades" column
+    // as soon as the (asynchronous) lookup comes back.
+    private final ObservableMap<String, Instant> deadDepositUnknownSince = FXCollections.observableHashMap();
+    private final Set<String> deadDepositRechecksInFlight = new HashSet<>();
+
+    // A transaction broadcast moments ago may not have reached the explorers yet, so the move to
+    // failed trades is only authorized by a second unanimous not-found answer arriving at least
+    // this long after the first observation.
+    static final Duration DEAD_DEPOSIT_SAFETY_INTERVAL = Duration.ofMinutes(30);
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -245,7 +255,7 @@ public class PendingTradesViewModel extends ActivatableWithDataModel<PendingTrad
                 if (confirms >= 0) {
                     // A provider returned a status for the tx, so it is not gone from the network,
                     // whatever its confirmation count. Drop an earlier unknown-to-all verdict.
-                    deadDepositTradeIds.remove(trade.getId());
+                    deadDepositUnknownSince.remove(trade.getId());
                 }
                 if (confirms >= 1) {
                     String key = "tradeUnconfirmedTooLong_" + trade.getShortId();
@@ -258,10 +268,22 @@ public class PendingTradesViewModel extends ActivatableWithDataModel<PendingTrad
                                 .show();
                     }
                 } else if (validator.getStatus() == FeeValidationStatus.NACK_BTC_TX_NOT_FOUND) {
+                    if (lacksDepositBroadcastEvidence(trade)) {
+                        // The seller sends DepositTxAndDelayedPayoutTxMessage before publishing the
+                        // deposit tx (fiat publication even waits for its delivery), so the buyer
+                        // can hold a signed deposit tx which was never broadcast. The explorers
+                        // truthfully not knowing it does not mean it is dead then; the seller can
+                        // still publish it later.
+                        log.info("Deposit tx of trade {} is unknown to all block explorers, but we have " +
+                                "no evidence it was ever broadcast, so no verdict is derived from that",
+                                trade.getShortId());
+                        return;
+                    }
                     // Every block explorer positively reported the deposit tx as unknown, which is what
                     // it looks like when one of its inputs has since been spent by another transaction.
-                    // Nodes will then neither relay nor mine it.
-                    deadDepositTradeIds.add(trade.getId());
+                    // Nodes will then neither relay nor mine it. Keep the first observation time: the
+                    // move to failed trades only unlocks after DEAD_DEPOSIT_SAFETY_INTERVAL.
+                    deadDepositUnknownSince.putIfAbsent(trade.getId(), Instant.now());
                     String key = "tradeDepositTxDead_" + trade.getShortId();
                     if (DontShowAgainLookup.showAgain(key)) {
                         new Popup().warning(Res.get("portfolio.pending.depositTxDead", trade.getShortId(), unconfirmedHours))
@@ -342,11 +364,70 @@ public class PendingTradesViewModel extends ActivatableWithDataModel<PendingTrad
     public boolean isDepositTxProvenDead(Trade trade) {
         // A tx which was only dropped from the mempools looks the same to us but can still confirm
         // later, so the marker never outlives an actual confirmation.
-        return trade != null && deadDepositTradeIds.contains(trade.getId()) && !trade.isDepositConfirmed();
+        return trade != null && deadDepositUnknownSince.containsKey(trade.getId()) && !trade.isDepositConfirmed();
     }
 
-    ObservableSet<String> getDeadDepositTradeIds() {
-        return deadDepositTradeIds;
+    ObservableMap<String, Instant> getDeadDepositUnknownSince() {
+        return deadDepositUnknownSince;
+    }
+
+    public enum DeadDepositRecheckResult {
+        STILL_DEAD, TOO_RECENT, FOUND, UNREACHABLE
+    }
+
+    // The dead verdict can be arbitrarily old by the time the user acts on it, so the move to
+    // failed trades re-checks the explorers and is only authorized by a fresh unanimous not-found
+    // answer arriving at least DEAD_DEPOSIT_SAFETY_INTERVAL after the first one. The handler is
+    // invoked on the UserThread, like all mempool lookup callbacks, and is not invoked at all
+    // when there is no recorded verdict for the trade or a re-check for it is already running.
+    public void recheckDeadDepositTx(Trade trade, Consumer<DeadDepositRecheckResult> resultHandler) {
+        String tradeId = trade.getId();
+        String depositTxId = trade.getDepositTxId();
+
+        if (depositTxId == null || !deadDepositUnknownSince.containsKey(tradeId)
+                || !deadDepositRechecksInFlight.add(tradeId)) {
+            return;
+        }
+        mempoolService.checkTxIsConfirmed(depositTxId, validator -> {
+            deadDepositRechecksInFlight.remove(tradeId);
+            Instant unknownSince = deadDepositUnknownSince.get(tradeId);
+            if (unknownSince == null) {
+                // A concurrent step 1 lookup revoked the verdict while this re-check was running.
+                resultHandler.accept(DeadDepositRecheckResult.FOUND);
+            } else if (validator.getStatus() == FeeValidationStatus.NACK_TX_LOOKUP_UNREACHABLE) {
+                resultHandler.accept(DeadDepositRecheckResult.UNREACHABLE);
+            } else if (validator.parseJsonValidateTx() >= 0) {
+                // A provider returned a status for the tx, so it is not gone from the network.
+                deadDepositUnknownSince.remove(tradeId);
+                resultHandler.accept(DeadDepositRecheckResult.FOUND);
+            } else if (validator.getStatus() != FeeValidationStatus.NACK_BTC_TX_NOT_FOUND) {
+                // Whatever else came back is no positive evidence of death.
+                resultHandler.accept(DeadDepositRecheckResult.UNREACHABLE);
+            } else if (Duration.between(unknownSince, Instant.now()).compareTo(DEAD_DEPOSIT_SAFETY_INTERVAL) < 0) {
+                resultHandler.accept(DeadDepositRecheckResult.TOO_RECENT);
+            } else {
+                resultHandler.accept(DeadDepositRecheckResult.STILL_DEAD);
+            }
+        });
+    }
+
+    private static boolean lacksDepositBroadcastEvidence(Trade trade) {
+        // The seller publishes the deposit tx himself, so his step 1 implies a broadcast. The
+        // buyer applies it from a message which the seller sends before publishing (fiat
+        // publication even waits for its delivery), so positive evidence is needed: either the
+        // wallet saw the network relay the tx before the message arrived (the confidence
+        // listener stops updating the state afterwards), or broadcast peers were seen on the
+        // committed tx. That evidence is persisted with the wallet but wiped by an SPV
+        // resync; without evidence no verdict is derived.
+        // See docs/specifications/trade/deposit-transaction-liveness.md.
+        if (!(trade instanceof BuyerTrade)) {
+            return false;
+        }
+        if (trade.getTradeState() == Trade.State.BUYER_SAW_DEPOSIT_TX_IN_NETWORK) {
+            return false;
+        }
+        Transaction depositTx = trade.getDepositTx();
+        return depositTx == null || depositTx.getConfidence().numBroadcastPeers() == 0;
     }
 
     //

--- a/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModel.java
+++ b/desktop/src/main/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModel.java
@@ -31,6 +31,7 @@ import bisq.core.network.MessageState;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OfferUtil;
 import bisq.core.provider.fee.FeeService;
+import bisq.core.provider.mempool.FeeValidationStatus;
 import bisq.core.provider.mempool.MempoolService;
 import bisq.core.trade.ClosedTradableManager;
 import bisq.core.trade.bisq_v1.TradeUtil;
@@ -63,10 +64,15 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableSet;
+
 import java.time.Duration;
 import java.time.Instant;
 
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -123,6 +129,10 @@ public class PendingTradesViewModel extends ActivatableWithDataModel<PendingTrad
     private final ObjectProperty<MessageState> messageStateProperty = new SimpleObjectProperty<>(MessageState.UNDEFINED);
     private Subscription tradeStateSubscription;
     private Subscription messageStateSubscription;
+    // Transient, UI-local marker: trades whose deposit tx every block explorer reported as unknown.
+    // Not persisted, so a restart re-evaluates the situation from scratch. Observable so the view can
+    // reveal the "move to failed trades" column as soon as the (asynchronous) lookup comes back.
+    private final ObservableSet<String> deadDepositTradeIds = FXCollections.observableSet(new HashSet<>());
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -210,7 +220,13 @@ public class PendingTradesViewModel extends ActivatableWithDataModel<PendingTrad
     }
 
     public void checkForTimeoutAtTradeStep1() {
+        // Pin the trade we are checking. The lookup is asynchronous and can take minutes, while the
+        // field follows the user's selection, so the result must not be applied to another trade.
+        Trade trade = this.trade;
         if (trade == null) {
+            return;
+        }
+        if (trade.getDepositTxId() == null) {
             return;
         }
         // Trade is waiting confirmation.  If it has been unconfirmed for too long, prompt the user.
@@ -218,20 +234,45 @@ public class PendingTradesViewModel extends ActivatableWithDataModel<PendingTrad
         if (unconfirmedHours >= 24 && !trade.hasFailed()) {
             // PR #6994 - only show a warning popup if a block explorer says it has confirmed
             mempoolService.checkTxIsConfirmed(trade.getDepositTxId(), (validator -> {
-                long confirms = validator.parseJsonValidateTx();
-                log.info("Mempool lookup of deposit tx returned {} confirms for trade {}", confirms, trade.getShortId());
-                if (confirms < 1) {
+                if (validator.getStatus() == FeeValidationStatus.NACK_TX_LOOKUP_UNREACHABLE) {
+                    // We could not get an answer from any block explorer, so we know nothing.
+                    log.info("Mempool lookup of deposit tx for trade {} could not reach any block explorer",
+                            trade.getShortId());
                     return;
                 }
-                String key = "tradeUnconfirmedTooLong_" + trade.getShortId();
-                if (DontShowAgainLookup.showAgain(key)) {
-                    new Popup().warning(Res.get("portfolio.pending.unconfirmedTooLong", trade.getShortId(), unconfirmedHours))
-                            .dontShowAgainId(key)
-                            .actionButtonText(Res.get("settings.net.reSyncSPVChainButton"))
-                            .closeButtonText(Res.get("shared.ok"))
-                            .onAction(GUIUtil::reSyncSPVChain)
-                            .show();
+                long confirms = validator.parseJsonValidateTx();
+                log.info("Mempool lookup of deposit tx returned {} confirms for trade {}", confirms, trade.getShortId());
+                if (confirms >= 0) {
+                    // A provider returned a status for the tx, so it is not gone from the network,
+                    // whatever its confirmation count. Drop an earlier unknown-to-all verdict.
+                    deadDepositTradeIds.remove(trade.getId());
                 }
+                if (confirms >= 1) {
+                    String key = "tradeUnconfirmedTooLong_" + trade.getShortId();
+                    if (DontShowAgainLookup.showAgain(key)) {
+                        new Popup().warning(Res.get("portfolio.pending.unconfirmedTooLong", trade.getShortId(), unconfirmedHours))
+                                .dontShowAgainId(key)
+                                .actionButtonText(Res.get("settings.net.reSyncSPVChainButton"))
+                                .closeButtonText(Res.get("shared.ok"))
+                                .onAction(GUIUtil::reSyncSPVChain)
+                                .show();
+                    }
+                } else if (validator.getStatus() == FeeValidationStatus.NACK_BTC_TX_NOT_FOUND) {
+                    // Every block explorer positively reported the deposit tx as unknown, which is what
+                    // it looks like when one of its inputs has since been spent by another transaction.
+                    // Nodes will then neither relay nor mine it.
+                    deadDepositTradeIds.add(trade.getId());
+                    String key = "tradeDepositTxDead_" + trade.getShortId();
+                    if (DontShowAgainLookup.showAgain(key)) {
+                        new Popup().warning(Res.get("portfolio.pending.depositTxDead", trade.getShortId(), unconfirmedHours))
+                                .dontShowAgainId(key)
+                                .actionButtonText(Res.get("settings.net.reSyncSPVChainButton"))
+                                .closeButtonText(Res.get("shared.ok"))
+                                .onAction(GUIUtil::reSyncSPVChain)
+                                .show();
+                    }
+                }
+                // confirms == 0 means the tx is sitting in a mempool: valid, just slow. Stay silent.
             }));
         }
     }
@@ -296,6 +337,16 @@ public class PendingTradesViewModel extends ActivatableWithDataModel<PendingTrad
 
     public boolean showDispute() {
         return getMaxTradePeriodDate() != null && new Date().after(getMaxTradePeriodDate());
+    }
+
+    public boolean isDepositTxProvenDead(Trade trade) {
+        // A tx which was only dropped from the mempools looks the same to us but can still confirm
+        // later, so the marker never outlives an actual confirmation.
+        return trade != null && deadDepositTradeIds.contains(trade.getId()) && !trade.isDepositConfirmed();
+    }
+
+    ObservableSet<String> getDeadDepositTradeIds() {
+        return deadDepositTradeIds;
     }
 
     //

--- a/desktop/src/test/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModelTest.java
@@ -1,0 +1,161 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.desktop.main.portfolio.pendingtrades;
+
+import bisq.desktop.Navigation;
+
+import bisq.core.account.witness.AccountAgeWitnessService;
+import bisq.core.dao.state.DaoStateService;
+import bisq.core.filter.FilterPolicyService;
+import bisq.core.network.MessageState;
+import bisq.core.offer.OfferUtil;
+import bisq.core.provider.mempool.FeeValidationStatus;
+import bisq.core.provider.mempool.MempoolService;
+import bisq.core.provider.mempool.TxValidator;
+import bisq.core.trade.ClosedTradableManager;
+import bisq.core.trade.bisq_v1.TradeUtil;
+import bisq.core.trade.model.bisq_v1.Trade;
+import bisq.core.trade.protocol.bisq_v1.model.ProcessModel;
+import bisq.core.user.DontShowAgainLookup;
+import bisq.core.user.Preferences;
+import bisq.core.user.User;
+import bisq.core.util.coin.BsqFormatter;
+import bisq.core.util.coin.CoinFormatter;
+import bisq.core.util.validation.BtcAddressValidator;
+
+import bisq.network.p2p.P2PService;
+
+import bisq.common.ClockWatcher;
+
+import javafx.beans.property.SimpleObjectProperty;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import java.util.Date;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PendingTradesViewModelTest {
+    private static final String TRADE_ID = "tradeId";
+    private static final String DEPOSIT_TX_ID = "depositTxId";
+
+    private Trade trade;
+    private MempoolService mempoolService;
+    private PendingTradesViewModel viewModel;
+    private int lookups;
+
+    @BeforeEach
+    void setUp() {
+        Preferences preferences = mock(Preferences.class);
+        when(preferences.showAgain(anyString())).thenReturn(false);
+        DontShowAgainLookup.setPreferences(preferences);
+
+        trade = mock(Trade.class);
+        when(trade.getId()).thenReturn(TRADE_ID);
+        when(trade.getShortId()).thenReturn(TRADE_ID);
+        when(trade.getDepositTxId()).thenReturn(DEPOSIT_TX_ID);
+        when(trade.getDate()).thenReturn(Date.from(Instant.now().minus(48, ChronoUnit.HOURS)));
+        when(trade.hasFailed()).thenReturn(false);
+        when(trade.isDepositConfirmed()).thenReturn(false);
+        when(trade.stateProperty()).thenReturn(new SimpleObjectProperty<>(Trade.State.PREPARATION));
+        ProcessModel processModel = mock(ProcessModel.class);
+        when(processModel.getPaymentStartedMessageStateProperty())
+                .thenReturn(new SimpleObjectProperty<>(MessageState.UNDEFINED));
+        when(trade.getProcessModel()).thenReturn(processModel);
+
+        mempoolService = mock(MempoolService.class);
+        viewModel = new PendingTradesViewModel(mock(PendingTradesDataModel.class),
+                mock(CoinFormatter.class),
+                mock(BsqFormatter.class),
+                mock(BtcAddressValidator.class),
+                mock(P2PService.class),
+                mempoolService,
+                mock(ClosedTradableManager.class),
+                mock(OfferUtil.class),
+                mock(TradeUtil.class),
+                mock(AccountAgeWitnessService.class),
+                mock(ClockWatcher.class),
+                mock(Navigation.class),
+                mock(User.class));
+        viewModel.onSelectedItemChanged(new PendingTradesListItem(trade, mock(CoinFormatter.class)));
+    }
+
+    @Test
+    void depositTxUnknownToAllProvidersIsForgottenOnceAProviderKnowsItAgain() {
+        deliver(txUnknownToAllProviders());
+        assertTrue(viewModel.isDepositTxProvenDead(trade));
+
+        // The tx turns up at a provider again, still unconfirmed. It is not gone from the network,
+        // so the trade must no longer be offered for moving to failed trades.
+        deliver(txKnownButUnconfirmed());
+        assertFalse(viewModel.isDepositTxProvenDead(trade));
+    }
+
+    @Test
+    void unreachableLookupNeitherFlagsNorClearsTheTrade() {
+        deliver(txLookupUnreachable());
+        assertFalse(viewModel.isDepositTxProvenDead(trade));
+
+        deliver(txUnknownToAllProviders());
+        assertTrue(viewModel.isDepositTxProvenDead(trade));
+
+        // Not being able to ask is not an answer, so it must not revoke the earlier verdict either.
+        deliver(txLookupUnreachable());
+        assertTrue(viewModel.isDepositTxProvenDead(trade));
+    }
+
+    // Each check runs its own lookup with its own result handler, so capture a fresh one every time.
+    @SuppressWarnings("unchecked")
+    private void deliver(TxValidator result) {
+        viewModel.checkForTimeoutAtTradeStep1();
+        ArgumentCaptor<Consumer<TxValidator>> captor = ArgumentCaptor.forClass(Consumer.class);
+        verify(mempoolService, times(++lookups)).checkTxIsConfirmed(eq(DEPOSIT_TX_ID), captor.capture());
+        captor.getAllValues().get(lookups - 1).accept(result);
+    }
+
+    private static TxValidator txUnknownToAllProviders() {
+        return newTxValidator().endResult(FeeValidationStatus.NACK_BTC_TX_NOT_FOUND);
+    }
+
+    private static TxValidator txLookupUnreachable() {
+        return newTxValidator().endResult(FeeValidationStatus.NACK_TX_LOOKUP_UNREACHABLE);
+    }
+
+    private static TxValidator txKnownButUnconfirmed() {
+        TxValidator txValidator = newTxValidator();
+        txValidator.setJsonTxt("{\"txid\":\"" + DEPOSIT_TX_ID + "\",\"status\":{\"confirmed\":false}}");
+        return txValidator;
+    }
+
+    private static TxValidator newTxValidator() {
+        return new TxValidator(mock(DaoStateService.class), DEPOSIT_TX_ID, mock(FilterPolicyService.class));
+    }
+}

--- a/desktop/src/test/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModelTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/portfolio/pendingtrades/PendingTradesViewModelTest.java
@@ -18,6 +18,7 @@
 package bisq.desktop.main.portfolio.pendingtrades;
 
 import bisq.desktop.Navigation;
+import bisq.desktop.main.portfolio.pendingtrades.PendingTradesViewModel.DeadDepositRecheckResult;
 
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.dao.state.DaoStateService;
@@ -29,6 +30,7 @@ import bisq.core.provider.mempool.MempoolService;
 import bisq.core.provider.mempool.TxValidator;
 import bisq.core.trade.ClosedTradableManager;
 import bisq.core.trade.bisq_v1.TradeUtil;
+import bisq.core.trade.model.bisq_v1.BuyerTrade;
 import bisq.core.trade.model.bisq_v1.Trade;
 import bisq.core.trade.protocol.bisq_v1.model.ProcessModel;
 import bisq.core.user.DontShowAgainLookup;
@@ -42,20 +44,26 @@ import bisq.network.p2p.P2PService;
 
 import bisq.common.ClockWatcher;
 
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionConfidence;
+
 import javafx.beans.property.SimpleObjectProperty;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
 import java.util.Date;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -78,18 +86,7 @@ class PendingTradesViewModelTest {
         when(preferences.showAgain(anyString())).thenReturn(false);
         DontShowAgainLookup.setPreferences(preferences);
 
-        trade = mock(Trade.class);
-        when(trade.getId()).thenReturn(TRADE_ID);
-        when(trade.getShortId()).thenReturn(TRADE_ID);
-        when(trade.getDepositTxId()).thenReturn(DEPOSIT_TX_ID);
-        when(trade.getDate()).thenReturn(Date.from(Instant.now().minus(48, ChronoUnit.HOURS)));
-        when(trade.hasFailed()).thenReturn(false);
-        when(trade.isDepositConfirmed()).thenReturn(false);
-        when(trade.stateProperty()).thenReturn(new SimpleObjectProperty<>(Trade.State.PREPARATION));
-        ProcessModel processModel = mock(ProcessModel.class);
-        when(processModel.getPaymentStartedMessageStateProperty())
-                .thenReturn(new SimpleObjectProperty<>(MessageState.UNDEFINED));
-        when(trade.getProcessModel()).thenReturn(processModel);
+        trade = mockTrade(Trade.class);
 
         mempoolService = mock(MempoolService.class);
         viewModel = new PendingTradesViewModel(mock(PendingTradesDataModel.class),
@@ -105,6 +102,28 @@ class PendingTradesViewModelTest {
                 mock(ClockWatcher.class),
                 mock(Navigation.class),
                 mock(User.class));
+        select(trade);
+    }
+
+    private static <T extends Trade> T mockTrade(Class<T> tradeClass) {
+        T trade = mock(tradeClass);
+        when(trade.getId()).thenReturn(TRADE_ID);
+        when(trade.getShortId()).thenReturn(TRADE_ID);
+        when(trade.getDepositTxId()).thenReturn(DEPOSIT_TX_ID);
+        // Twice the 24 hour threshold which triggers the explorer lookup.
+        when(trade.getDate()).thenReturn(Date.from(Instant.now().minus(48, ChronoUnit.HOURS)));
+        when(trade.hasFailed()).thenReturn(false);
+        when(trade.isDepositConfirmed()).thenReturn(false);
+        when(trade.stateProperty()).thenReturn(new SimpleObjectProperty<>(Trade.State.PREPARATION));
+        ProcessModel processModel = mock(ProcessModel.class);
+        when(processModel.getPaymentStartedMessageStateProperty())
+                .thenReturn(new SimpleObjectProperty<>(MessageState.UNDEFINED));
+        when(trade.getProcessModel()).thenReturn(processModel);
+        return trade;
+    }
+
+    private void select(Trade trade) {
+        this.trade = trade;
         viewModel.onSelectedItemChanged(new PendingTradesListItem(trade, mock(CoinFormatter.class)));
     }
 
@@ -132,6 +151,145 @@ class PendingTradesViewModelTest {
         assertTrue(viewModel.isDepositTxProvenDead(trade));
     }
 
+    @Test
+    void buyerWithoutNetworkSightingOfTheDepositTxIsNeverFlagged() {
+        BuyerTrade buyerTrade = mockTrade(BuyerTrade.class);
+        when(buyerTrade.getTradeState()).thenReturn(Trade.State.BUYER_RECEIVED_DEPOSIT_TX_PUBLISHED_MSG);
+        select(buyerTrade);
+
+        // The seller sends the deposit tx to the buyer before broadcasting it (fiat publication
+        // even waits for the delivery), so all explorers truthfully not knowing the tx is no
+        // evidence of death.
+        deliver(txUnknownToAllProviders());
+        assertFalse(viewModel.isDepositTxProvenDead(buyerTrade));
+    }
+
+    @Test
+    void buyerWhoSawTheDepositTxInTheNetworkIsFlagged() {
+        BuyerTrade buyerTrade = mockTrade(BuyerTrade.class);
+        when(buyerTrade.getTradeState()).thenReturn(Trade.State.BUYER_SAW_DEPOSIT_TX_IN_NETWORK);
+        select(buyerTrade);
+
+        deliver(txUnknownToAllProviders());
+        assertTrue(viewModel.isDepositTxProvenDead(buyerTrade));
+    }
+
+    @Test
+    void moveIsOnlyAuthorizedByAFreshVerdictAfterTheSafetyInterval() {
+        deliver(txUnknownToAllProviders());
+
+        // The re-check confirms the verdict, but the first observation is too recent: a tx
+        // broadcast moments ago may not have reached the explorers yet.
+        assertEquals(DeadDepositRecheckResult.TOO_RECENT, recheck(txUnknownToAllProviders()));
+
+        // Exactly the safety interval suffices: the rule is "at least".
+        viewModel.getDeadDepositUnknownSince().put(TRADE_ID,
+                Instant.now().minus(PendingTradesViewModel.DEAD_DEPOSIT_SAFETY_INTERVAL));
+        assertEquals(DeadDepositRecheckResult.STILL_DEAD, recheck(txUnknownToAllProviders()));
+    }
+
+    @Test
+    void buyerWithBroadcastPeersOnTheDepositTxIsFlagged() {
+        BuyerTrade buyerTrade = mockTrade(BuyerTrade.class);
+        when(buyerTrade.getTradeState()).thenReturn(Trade.State.BUYER_RECEIVED_DEPOSIT_TX_PUBLISHED_MSG);
+        Transaction depositTx = mock(Transaction.class);
+        TransactionConfidence confidence = mock(TransactionConfidence.class);
+        when(confidence.numBroadcastPeers()).thenReturn(1);
+        when(depositTx.getConfidence()).thenReturn(confidence);
+        when(buyerTrade.getDepositTx()).thenReturn(depositTx);
+        select(buyerTrade);
+
+        // The wallet saw peers relay the committed tx, which is broadcast evidence even though
+        // the network-sighting state is unreachable after the message was processed.
+        deliver(txUnknownToAllProviders());
+        assertTrue(viewModel.isDepositTxProvenDead(buyerTrade));
+    }
+
+    @Test
+    void buyerWithoutBroadcastPeersOnTheDepositTxIsNotFlagged() {
+        BuyerTrade buyerTrade = mockTrade(BuyerTrade.class);
+        when(buyerTrade.getTradeState()).thenReturn(Trade.State.BUYER_RECEIVED_DEPOSIT_TX_PUBLISHED_MSG);
+        Transaction depositTx = mock(Transaction.class);
+        TransactionConfidence confidence = mock(TransactionConfidence.class);
+        when(confidence.numBroadcastPeers()).thenReturn(0);
+        when(depositTx.getConfidence()).thenReturn(confidence);
+        when(buyerTrade.getDepositTx()).thenReturn(depositTx);
+        select(buyerTrade);
+
+        // A committed but never relayed tx carries no broadcast evidence.
+        deliver(txUnknownToAllProviders());
+        assertFalse(viewModel.isDepositTxProvenDead(buyerTrade));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void verdictRevokedWhileRecheckRunsIsTreatedAsFound() {
+        deliver(txUnknownToAllProviders());
+
+        AtomicReference<DeadDepositRecheckResult> outcome = new AtomicReference<>();
+        viewModel.recheckDeadDepositTx(trade, outcome::set);
+        // A concurrent step 1 lookup revokes the verdict while the re-check is in flight.
+        viewModel.getDeadDepositUnknownSince().remove(TRADE_ID);
+        ArgumentCaptor<Consumer<TxValidator>> captor = ArgumentCaptor.forClass(Consumer.class);
+        verify(mempoolService, times(++lookups)).checkTxIsConfirmed(eq(DEPOSIT_TX_ID), captor.capture());
+        captor.getAllValues().get(lookups - 1).accept(txUnknownToAllProviders());
+
+        assertEquals(DeadDepositRecheckResult.FOUND, outcome.get());
+    }
+
+    @Test
+    void bypassedRecheckDoesNotAuthorizeTheMove() {
+        deliver(txUnknownToAllProviders());
+
+        // A bypassed check carries no fresh evidence, so it must not authorize the move.
+        assertEquals(DeadDepositRecheckResult.UNREACHABLE, recheck(txCheckBypassed()));
+        assertTrue(viewModel.isDepositTxProvenDead(trade));
+    }
+
+    @Test
+    void onlyOneRecheckRunsAtATime() {
+        deliver(txUnknownToAllProviders());
+
+        viewModel.recheckDeadDepositTx(trade, result -> {});
+        viewModel.recheckDeadDepositTx(trade, result -> {});
+        verify(mempoolService, times(++lookups)).checkTxIsConfirmed(eq(DEPOSIT_TX_ID), any());
+    }
+
+    @Test
+    void firstObservationTimeIsKeptAcrossRepeatedLookups() {
+        deliver(txUnknownToAllProviders());
+        Instant firstObservation = viewModel.getDeadDepositUnknownSince().get(TRADE_ID);
+
+        deliver(txUnknownToAllProviders());
+        assertEquals(firstObservation, viewModel.getDeadDepositUnknownSince().get(TRADE_ID));
+    }
+
+    @Test
+    void recheckDropsTheVerdictWhenAProviderKnowsTheTxAgain() {
+        deliver(txUnknownToAllProviders());
+
+        assertEquals(DeadDepositRecheckResult.FOUND, recheck(txKnownButUnconfirmed()));
+        assertFalse(viewModel.isDepositTxProvenDead(trade));
+    }
+
+    @Test
+    void unreachableRecheckDoesNotAuthorizeTheMoveButKeepsTheVerdict() {
+        deliver(txUnknownToAllProviders());
+
+        assertEquals(DeadDepositRecheckResult.UNREACHABLE, recheck(txLookupUnreachable()));
+        assertTrue(viewModel.isDepositTxProvenDead(trade));
+    }
+
+    @SuppressWarnings("unchecked")
+    private DeadDepositRecheckResult recheck(TxValidator result) {
+        AtomicReference<DeadDepositRecheckResult> outcome = new AtomicReference<>();
+        viewModel.recheckDeadDepositTx(trade, outcome::set);
+        ArgumentCaptor<Consumer<TxValidator>> captor = ArgumentCaptor.forClass(Consumer.class);
+        verify(mempoolService, times(++lookups)).checkTxIsConfirmed(eq(DEPOSIT_TX_ID), captor.capture());
+        captor.getAllValues().get(lookups - 1).accept(result);
+        return outcome.get();
+    }
+
     // Each check runs its own lookup with its own result handler, so capture a fresh one every time.
     @SuppressWarnings("unchecked")
     private void deliver(TxValidator result) {
@@ -147,6 +305,10 @@ class PendingTradesViewModelTest {
 
     private static TxValidator txLookupUnreachable() {
         return newTxValidator().endResult(FeeValidationStatus.NACK_TX_LOOKUP_UNREACHABLE);
+    }
+
+    private static TxValidator txCheckBypassed() {
+        return newTxValidator().endResult(FeeValidationStatus.ACK_CHECK_BYPASSED);
     }
 
     private static TxValidator txKnownButUnconfirmed() {

--- a/docs/specifications/README.md
+++ b/docs/specifications/README.md
@@ -58,6 +58,7 @@ specification says so explicitly instead of describing the implementation as if 
 | Specification | Covers |
 |---|---|
 | [`trade/altcoin-volume-precision.md`](trade/altcoin-volume-precision.md) | Rounding of altcoin trade volumes to the asset's chain precision, and the rejection of volumes that round to zero. |
+| [`trade/deposit-transaction-liveness.md`](trade/deposit-transaction-liveness.md) | The block-explorer evidence rules for classifying a deposit transaction as dead and for authorizing the move to failed trades. |
 | [`trade/fiat-buyer-payment-account-validation.md`](trade/fiat-buyer-payment-account-validation.md) | Contract-bound buyer payment-account validation and the fiat deposit/settlement gates that depend on it. |
 | [`trade/withdrawal-completion.md`](trade/withdrawal-completion.md) | The completion invariant of a trade payout withdrawal: local wallet commit, one terminal outcome per request, and broadcast failure as a notification. |
 | [`trade/xmr-payment-proof-timestamp.md`](trade/xmr-payment-proof-timestamp.md) | The timestamp rule of the XMR payment proof used for automatic confirmation, and why it is one-sided. |

--- a/docs/specifications/trade/deposit-transaction-liveness.md
+++ b/docs/specifications/trade/deposit-transaction-liveness.md
@@ -53,8 +53,10 @@ first unanimous not-found answer.
 
 ## Messaging
 
-A dead-deposit classification must never describe the trade funds as locked: nothing is locked
-while the deposit is unconfirmed. The messaging must state that the verdict comes from external
+A dead-deposit classification must never describe the trade funds as locked in the deposit: an
+unconfirmed deposit locks nothing in the escrow. The wallet inputs funding it remain reserved
+until it confirms or is removed, and the messaging must keep the two apart. The messaging must
+further state that the verdict comes from external
 services, that a transaction dropped from the mempools can still confirm later, that support
 options are not available while the trade is in failed trades, and that the trade can be moved
 back from there.

--- a/docs/specifications/trade/deposit-transaction-liveness.md
+++ b/docs/specifications/trade/deposit-transaction-liveness.md
@@ -1,0 +1,71 @@
+# Deposit transaction liveness
+
+## Scope
+
+This specification defines when block-explorer evidence may classify an unconfirmed deposit
+transaction as no longer confirmable, and when that classification may authorize moving the trade
+to failed trades. It covers the checks run from the deposit-confirmation step of the pending
+trades view. It does not cover fee validation, which shares the lookup machinery but fails closed
+on its own rules, nor purely informational status displays such as the dispute summary's payout
+transaction status, which derive no verdict and gate no action.
+
+## Evidence rule
+
+A deposit transaction is treated as unknown to the network only when every configured explorer
+provider positively answered that it does not know the transaction. The providers are queried in
+rotation; a transport failure, a malformed answer or an unreachable provider is no information and
+must neither produce nor revoke a verdict. A single provider returning any status for the
+transaction, confirmed or not, proves it is not gone and revokes an earlier verdict.
+
+The lookup starts only after the trade has been unconfirmed for 24 hours. That threshold is a
+trigger heuristic to avoid querying explorers for young trades; it is not evidence, because it
+measures the take-offer time, not the transaction's publication.
+
+## Publication evidence
+
+A unanimous not-found answer only means the transaction is dead if the transaction was actually
+broadcast. The seller publishes the deposit transaction himself, so reaching the
+deposit-confirmation step implies a broadcast on his side. The buyer receives the transaction in a
+message which the seller sends before publishing; for fiat trades publication additionally waits
+for that message's delivery (one of the two publication prerequisites in
+[`fiat-buyer-payment-account-validation.md`](fiat-buyer-payment-account-validation.md)). The buyer
+therefore needs positive broadcast evidence: either his wallet saw the network relay the
+transaction before the message arrived, or broadcast peers were observed on the committed
+transaction afterwards. Without such evidence no verdict may be derived, however the explorers
+answer.
+
+## Safety interval and re-validation
+
+A transaction broadcast moments ago may not have reached the explorers yet, so one unanimous
+not-found answer is not sufficient to act on. Moving the trade to failed trades requires a second
+unanimous not-found answer, obtained by a fresh lookup at the moment the user invokes the action,
+arriving at least 30 minutes after the first observation. A transport failure during that
+re-validation blocks the action instead of falling back to the earlier verdict, and a provider
+returning a status for the transaction cancels the verdict entirely.
+
+## Verdict lifecycle
+
+The verdict is transient and local to the user interface. It is not persisted; a restart
+re-evaluates the situation from scratch. It never outlives a confirmation of the deposit
+transaction, and it is dropped as soon as any provider returns a status for the transaction. The
+first observation time is kept across repeated lookups so the safety interval measures from the
+first unanimous not-found answer.
+
+## Messaging
+
+A dead-deposit classification must never describe the trade funds as locked: nothing is locked
+while the deposit is unconfirmed. The messaging must state that the verdict comes from external
+services, that a transaction dropped from the mempools can still confirm later, that support
+options are not available while the trade is in failed trades, and that the trade can be moved
+back from there.
+
+## Known limitations
+
+A transaction that was broadcast and later dropped from all mempools is indistinguishable from one
+whose input was spent by a conflicting transaction; the dropped one can still confirm. The rules
+above therefore only gate a manual, reversible user action and never an automatic transition.
+
+The buyer's broadcast-peer evidence is persisted with the wallet and survives a restart, but an
+SPV resync replays the wallet and wipes it. A buyer who resyncs after the transaction vanished
+from the network has no broadcast evidence any more and is not offered the verdict; the support
+path remains available in that case.


### PR DESCRIPTION
Rebased https://github.com/bisq-network/bisq/pull/8009 on master and resolve conflict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Detects deposit transactions reported as missing by all available block explorers.
  * Adds clear guidance for reviewing, rechecking, and moving affected trades to failed status.
  * Requires a 30-minute safety interval and a fresh verification before finalizing the move.

* **Bug Fixes**
  * Distinguishes transactions that are genuinely unknown from temporary explorer connectivity problems.
  * Shows more accurate pending-trade and fee-validation messages when transaction lookups cannot be completed.

* **Documentation**
  * Added a specification describing deposit transaction liveness checks and handling rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->