### PR TITLE
Replace deprecated Charsets.UTF_8 with StandardCharsets.UTF_8

### DIFF
--- a/core/src/test/java/bisq/core/account/sign/SignedWitnessServiceTest.java
+++ b/core/src/test/java/bisq/core/account/sign/SignedWitnessServiceTest.java
@@ -35,14 +35,14 @@ import bisq.common.util.Utilities;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.ECKey;
 
-import com.google.common.base.Charsets;
-
 import java.security.KeyPair;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
+
+import java.nio.charset.StandardCharsets;
 
 import java.util.Date;
 import java.util.List;
@@ -118,7 +118,7 @@ public class SignedWitnessServiceTest {
         peer1KeyPair = Sig.generateKeyPair();
         peer2KeyPair = Sig.generateKeyPair();
         peer3KeyPair = Sig.generateKeyPair();
-        signature1 = arbitrator1Key.signMessage(Utilities.encodeToHex(account1DataHash)).getBytes(Charsets.UTF_8);
+        signature1 = arbitrator1Key.signMessage(Utilities.encodeToHex(account1DataHash)).getBytes(StandardCharsets.UTF_8);
         signature2 = Sig.sign(peer1KeyPair.getPrivate(), account2DataHash);
         signature3 = Sig.sign(peer2KeyPair.getPrivate(), account3DataHash);
         date1 = getTodayMinusNDays(SIGN_AGE_1);
@@ -254,7 +254,7 @@ public class SignedWitnessServiceTest {
     public void testInvalidArbitratorSignatureDoesNotCountAsSignedByArbitrator() {
         SignedWitness sw1 = new SignedWitness(ARBITRATOR,
                 account1DataHash,
-                "invalid-arbitrator-signature".getBytes(Charsets.UTF_8),
+                "invalid-arbitrator-signature".getBytes(StandardCharsets.UTF_8),
                 signer1PubKey,
                 witnessOwner1PubKey,
                 date1,
@@ -323,11 +323,11 @@ public class SignedWitnessServiceTest {
         // for the same account. The valid one must still lift the account to arbitrator-signed.
         ECKey secondArbitratorKey = LowRSigningKey.from(new ECKey());
         byte[] validSignature = secondArbitratorKey.signMessage(Utilities.encodeToHex(account1DataHash))
-                .getBytes(Charsets.UTF_8);
+                .getBytes(StandardCharsets.UTF_8);
 
         SignedWitness forged = new SignedWitness(ARBITRATOR,
                 account1DataHash,
-                "invalid-arbitrator-signature".getBytes(Charsets.UTF_8),
+                "invalid-arbitrator-signature".getBytes(StandardCharsets.UTF_8),
                 signer1PubKey,
                 witnessOwner1PubKey,
                 date1,
@@ -384,7 +384,7 @@ public class SignedWitnessServiceTest {
 
     @Test
     public void testInvalidPeerSignatureDoesNotVerify() throws Exception {
-        byte[] invalidSignature = Sig.sign(peer1KeyPair.getPrivate(), "wrong-message".getBytes(Charsets.UTF_8));
+        byte[] invalidSignature = Sig.sign(peer1KeyPair.getPrivate(), "wrong-message".getBytes(StandardCharsets.UTF_8));
         SignedWitness signedWitness = new SignedWitness(TRADE,
                 account2DataHash,
                 invalidSignature,
@@ -405,7 +405,7 @@ public class SignedWitnessServiceTest {
                 witnessOwner2PubKey,
                 date2,
                 tradeAmount2);
-        byte[] invalidSignature = Sig.sign(peer1KeyPair.getPrivate(), "wrong-message".getBytes(Charsets.UTF_8));
+        byte[] invalidSignature = Sig.sign(peer1KeyPair.getPrivate(), "wrong-message".getBytes(StandardCharsets.UTF_8));
         SignedWitness invalidSignedWitness = new SignedWitness(TRADE,
                 account2DataHash,
                 invalidSignature,
@@ -553,7 +553,7 @@ public class SignedWitnessServiceTest {
         KeyPair signedKeyPair = Sig.generateKeyPair();
         int iterations = 1002;
         for (int i = 0; i < iterations; i++) {
-            byte[] accountDataHash = org.bitcoinj.core.Utils.sha256hash160(String.valueOf(i).getBytes(Charsets.UTF_8));
+            byte[] accountDataHash = org.bitcoinj.core.Utils.sha256hash160(String.valueOf(i).getBytes(StandardCharsets.UTF_8));
             long accountCreationTime = getTodayMinusNDays((iterations - i) * (SignedWitnessService.SIGNER_AGE_DAYS + 1));
             aew = new AccountAgeWitness(accountDataHash, accountCreationTime);
             String accountDataHashAsHexString = Utilities.encodeToHex(accountDataHash);
@@ -564,7 +564,7 @@ public class SignedWitnessServiceTest {
                 ECKey arbitratorKey = LowRSigningKey.from(new ECKey());
                 signedKeyPair = Sig.generateKeyPair();
                 String signature1String = arbitratorKey.signMessage(accountDataHashAsHexString);
-                signature = signature1String.getBytes(Charsets.UTF_8);
+                signature = signature1String.getBytes(StandardCharsets.UTF_8);
                 signerPubKey = arbitratorKey.getPubKey();
             } else {
                 signerKeyPair = signedKeyPair;
@@ -798,7 +798,7 @@ public class SignedWitnessServiceTest {
     public void testBanFilterTwoTrees() {
         // Signer 2 is signed by arbitrator
         signer2PubKey = arbitrator1Key.getPubKey();
-        signature2 = arbitrator1Key.signMessage(Utilities.encodeToHex(account2DataHash)).getBytes(Charsets.UTF_8);
+        signature2 = arbitrator1Key.signMessage(Utilities.encodeToHex(account2DataHash)).getBytes(StandardCharsets.UTF_8);
 
         SignedWitness sw1 = new SignedWitness(ARBITRATOR, account1DataHash, signature1, signer1PubKey, witnessOwner1PubKey, date1, tradeAmount1);
         SignedWitness sw2 = new SignedWitness(ARBITRATOR, account2DataHash, signature2, signer2PubKey, witnessOwner2PubKey, date2, tradeAmount2);
@@ -835,7 +835,7 @@ public class SignedWitnessServiceTest {
     public void testBanFilterJoinedTrees() throws Exception {
         // Signer 2 is signed by arbitrator
         signer2PubKey = arbitrator1Key.getPubKey();
-        signature2 = arbitrator1Key.signMessage(Utilities.encodeToHex(account2DataHash)).getBytes(Charsets.UTF_8);
+        signature2 = arbitrator1Key.signMessage(Utilities.encodeToHex(account2DataHash)).getBytes(StandardCharsets.UTF_8);
 
         // Peer1 owns both account1 and account2
 //        witnessOwner2PubKey = witnessOwner1PubKey;

--- a/core/src/test/java/bisq/core/account/sign/SignedWitnessTest.java
+++ b/core/src/test/java/bisq/core/account/sign/SignedWitnessTest.java
@@ -6,11 +6,11 @@ import bisq.common.util.Utilities;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.Utils;
 
-import com.google.common.base.Charsets;
-
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+
+import java.nio.charset.StandardCharsets;
 
 import java.util.concurrent.TimeUnit;
 
@@ -36,7 +36,7 @@ public class SignedWitnessTest {
         arbitrator1Key = new ECKey();
         witnessOwner1PubKey = Sig.getPublicKeyBytes(Sig.generateKeyPair().getPublic());
         witnessHash = Utils.sha256hash160(new byte[]{1});
-        witnessHashSignature = arbitrator1Key.signMessage(Utilities.encodeToHex(witnessHash)).getBytes(Charsets.UTF_8);
+        witnessHashSignature = arbitrator1Key.signMessage(Utilities.encodeToHex(witnessHash)).getBytes(StandardCharsets.UTF_8);
     }
 
     @Test

--- a/core/src/test/java/bisq/core/alert/AlertManagerTest.java
+++ b/core/src/test/java/bisq/core/alert/AlertManagerTest.java
@@ -34,6 +34,8 @@ import com.google.common.base.Charsets;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.Utils;
 
+import java.nio.charset.StandardCharsets;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -189,7 +191,7 @@ public class AlertManagerTest {
     private Alert signedAlert(String message) {
         Alert alert = new Alert(message, false, false, "");
         ECKey signingKey = ECKey.fromPrivate(new BigInteger(1, HEX.decode(DevEnv.getDEV_PRIVILEGE_PRIV_KEY())));
-        String alertMessageAsHex = Utils.HEX.encode(message.getBytes(Charsets.UTF_8));
+        String alertMessageAsHex = Utils.HEX.encode(message.getBytes(StandardCharsets.UTF_8));
         String signatureAsBase64 = LowRSigningKey.from(signingKey).signMessage(alertMessageAsHex);
         alert.setSigAndPubKey(signatureAsBase64, Sig.generateKeyPair().getPublic());
         return alert;


### PR DESCRIPTION
StandardCharsets is built into Java 7+, allowing us to rely on the standard library instead of the deprecated Guava implementation. This helps reduce our reliance on external dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test encoding operations to use the standard UTF-8 character set implementation.
  * Maintained existing test behavior, assertions, and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->