### PR TITLE
Suppress deprecation warnings for ArbitrationManager

### DIFF
--- a/core/src/test/java/bisq/core/account/sign/SignedWitnessServiceTest.java
+++ b/core/src/test/java/bisq/core/account/sign/SignedWitnessServiceTest.java
@@ -98,7 +98,7 @@ public class SignedWitnessServiceTest {
     @BeforeEach
     public void setup() throws Exception {
         AppendOnlyDataStoreService appendOnlyDataStoreService = mock(AppendOnlyDataStoreService.class);
-        ArbitratorManager arbitratorManager = mock(ArbitratorManager.class);
+        @SuppressWarnings("deprecation") ArbitratorManager arbitratorManager = mock(ArbitratorManager.class);
         when(arbitratorManager.isPublicKeyInList(any())).thenReturn(true);
         keyRing = mock(KeyRing.class);
         p2pService = mock(P2PService.class);
@@ -271,7 +271,7 @@ public class SignedWitnessServiceTest {
         // A cryptographically valid signature is present, but the signer key is NOT in the
         // arbitrator manager's accepted list. The account must not be treated as arbitrator-signed.
         AppendOnlyDataStoreService appendOnlyDataStoreService = mock(AppendOnlyDataStoreService.class);
-        ArbitratorManager strictArbitratorManager = mock(ArbitratorManager.class);
+        @SuppressWarnings("deprecation") ArbitratorManager strictArbitratorManager = mock(ArbitratorManager.class);
         when(strictArbitratorManager.isPublicKeyInList(any())).thenReturn(false);
         SignedWitnessService strictService = new SignedWitnessService(keyRing, p2pService,
                 strictArbitratorManager, null, appendOnlyDataStoreService, filterPolicyService, false, clock);

--- a/core/src/test/java/bisq/core/account/witness/AccountAgeWitnessServiceTest.java
+++ b/core/src/test/java/bisq/core/account/witness/AccountAgeWitnessServiceTest.java
@@ -120,7 +120,7 @@ public class AccountAgeWitnessServiceTest {
         chargeBackRisk = mock(ChargeBackRisk.class);
         AppendOnlyDataStoreService dataStoreService = mock(AppendOnlyDataStoreService.class);
         P2PService p2pService = mock(P2PService.class);
-        ArbitratorManager arbitratorManager = mock(ArbitratorManager.class);
+        @SuppressWarnings("deprecation") ArbitratorManager arbitratorManager = mock(ArbitratorManager.class);
         when(arbitratorManager.isPublicKeyInList(any())).thenReturn(true);
         AppendOnlyDataStoreService appendOnlyDataStoreService = mock(AppendOnlyDataStoreService.class);
         filterPolicyService = mock(FilterPolicyService.class);

--- a/desktop/src/test/java/bisq/desktop/main/funds/transactions/TransactionAwareTradeTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/funds/transactions/TransactionAwareTradeTest.java
@@ -42,10 +42,12 @@ public class TransactionAwareTradeTest {
     private static final Sha256Hash XID = Sha256Hash.wrap("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
 
     private Transaction transaction;
+    @SuppressWarnings("deprecation")
     private ArbitrationManager arbitrationManager;
     private Trade delegate;
     private TransactionAwareTradable trade;
 
+    @SuppressWarnings("deprecation")
     @BeforeEach
     public void setUp() {
         this.transaction = mock(Transaction.class);


### PR DESCRIPTION
ArbitrationManager was recently deprecated, but the codebase still contains numerous references to it. This change temporarily suppresses the resulting deprecation warnings to keep the build output clean while we migrate to the new implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test annotations to suppress deprecation warnings.
  * No changes to application behavior, test logic, or assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->