### PR TITLE
Suppress legacy DaoState serialization warnings

### DIFF
--- a/core/src/test/java/bisq/core/dao/state/model/DaoStateCanonicalEncoderTest.java
+++ b/core/src/test/java/bisq/core/dao/state/model/DaoStateCanonicalEncoderTest.java
@@ -218,7 +218,7 @@ class DaoStateCanonicalEncoderTest {
     void serializesLegacyDaoStateMapsInJava11HashMapIterationOrder() throws Exception {
         DaoState daoState = getDaoStateWithMaps();
 
-        protobuf.DaoState proto = protobuf.DaoState.parseFrom(daoState.getSerializedStateForHashChainLegacy());
+        @SuppressWarnings("deprecation") protobuf.DaoState proto = protobuf.DaoState.parseFrom(daoState.getSerializedStateForHashChainLegacy());
 
         assertEquals(JAVA_11_HASH_MAP_ORDER, new ArrayList<>(proto.getIssuanceMapMap().keySet()));
         assertEquals(JAVA_11_TX_OUTPUT_KEY_HASH_MAP_ORDER,
@@ -247,7 +247,7 @@ class DaoStateCanonicalEncoderTest {
 
     @Test
     void serializesLegacyEmptyDaoStateHashChainWithoutLastBlock() throws Exception {
-        protobuf.DaoState proto = protobuf.DaoState.parseFrom(new DaoState().getSerializedStateForHashChainLegacy());
+        @SuppressWarnings("deprecation") protobuf.DaoState proto = protobuf.DaoState.parseFrom(new DaoState().getSerializedStateForHashChainLegacy());
 
         assertEquals(0, proto.getBlocksCount());
     }


### PR DESCRIPTION
The method DaoState.getSerializedStateForHashChainLegacy was recently deprecated, but it is still used until the canonical encoding migration verification is complete.

This change temporarily suppresses the resulting deprecation warnings to keep the build output clean while we migrate to the new implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test annotations to suppress deprecation warnings.
  * No changes to test behavior or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->