### PR TITLE
Suppress deprecation warnings for Venmo

### DIFF
--- a/core/src/test/java/bisq/core/filter/FilterPolicyServiceTests.java
+++ b/core/src/test/java/bisq/core/filter/FilterPolicyServiceTests.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class FilterPolicyServiceTests {
+    @SuppressWarnings("deprecation")
     @Test
     void bansWhenDenyListBansAndNoNetworkFilterBans() {
         Properties properties = new Properties();


### PR DESCRIPTION
Venmo was deprecated and removed as an active payment method due to high chargeback risk. This change suppresses the resulting deprecation warnings to keep the build output clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed deprecation warnings from a test without changing test behavior or coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->