### PR TITLE
Replace Locale constructor call with Locale.of

### DIFF
--- a/core/src/test/java/bisq/core/locale/BankUtilTest.java
+++ b/core/src/test/java/bisq/core/locale/BankUtilTest.java
@@ -13,8 +13,8 @@ public class BankUtilTest {
 
     @BeforeEach
     public void setup() {
-        Locale.setDefault(new Locale("en", "US"));
-        GlobalSettings.setLocale(new Locale("en", "US"));
+        Locale.setDefault(Locale.of("en", "US"));
+        GlobalSettings.setLocale(Locale.of("en", "US"));
         Res.setBaseCurrencyCode("BTC");
         Res.setBaseCurrencyName("Bitcoin");
     }

--- a/core/src/test/java/bisq/core/locale/CurrencyUtilTest.java
+++ b/core/src/test/java/bisq/core/locale/CurrencyUtilTest.java
@@ -46,7 +46,7 @@ public class CurrencyUtilTest {
     @BeforeEach
     public void setup() {
 
-        Locale.setDefault(new Locale("en", "US"));
+        Locale.setDefault(Locale.of("en", "US"));
         Res.setBaseCurrencyCode("BTC");
         Res.setBaseCurrencyName("Bitcoin");
     }

--- a/core/src/test/java/bisq/core/user/PreferencesTest.java
+++ b/core/src/test/java/bisq/core/user/PreferencesTest.java
@@ -59,7 +59,7 @@ public class PreferencesTest {
 
     @BeforeEach
     public void setUp() {
-        Locale en_US = new Locale("en", "US");
+        Locale en_US = Locale.of("en", "US");
         Locale.setDefault(en_US);
         GlobalSettings.setLocale(en_US);
         Res.setBaseCurrencyCode("BTC");
@@ -142,7 +142,7 @@ public class PreferencesTest {
         PreferencesPayload payload = mock(PreferencesPayload.class);
 
         List<FiatCurrency> fiatCurrencies = new ArrayList<>();
-        FiatCurrency usd = new FiatCurrency(Currency.getInstance("USD"), new Locale("de", "AT"));
+        FiatCurrency usd = new FiatCurrency(Currency.getInstance("USD"), Locale.of("de", "AT"));
         fiatCurrencies.add(usd);
 
         assertEquals("US-Dollar (USD)", usd.getNameAndCode());

--- a/core/src/test/java/bisq/core/util/FormattingUtilsTest.java
+++ b/core/src/test/java/bisq/core/util/FormattingUtilsTest.java
@@ -28,7 +28,7 @@ public class FormattingUtilsTest {
 
     @BeforeEach
     public void setUp() {
-        Locale.setDefault(new Locale("en", "US"));
+        Locale.setDefault(Locale.of("en", "US"));
         Res.setBaseCurrencyCode("BTC");
         Res.setBaseCurrencyName("Bitcoin");
     }

--- a/core/src/test/java/bisq/core/util/RegexValidatorTest.java
+++ b/core/src/test/java/bisq/core/util/RegexValidatorTest.java
@@ -35,8 +35,8 @@ public class RegexValidatorTest {
 
     @BeforeEach
     public void setup() {
-        Locale.setDefault(new Locale("en", "US"));
-        GlobalSettings.setLocale(new Locale("en", "US"));
+        Locale.setDefault(Locale.of("en", "US"));
+        GlobalSettings.setLocale(Locale.of("en", "US"));
         Res.setBaseCurrencyCode("BTC");
         Res.setBaseCurrencyName("Bitcoin");
     }

--- a/desktop/src/test/java/bisq/desktop/MarketsPrintTool.java
+++ b/desktop/src/test/java/bisq/desktop/MarketsPrintTool.java
@@ -32,7 +32,7 @@ public class MarketsPrintTool {
         // Prints out all coins in the format used in the market_currency_selector.html.
         // Run that and copy paste the result to the market_currency_selector.html at new releases.
         StringBuilder sb = new StringBuilder();
-        Locale.setDefault(new Locale("en", "US"));
+        Locale.setDefault(Locale.of("en", "US"));
 
         // <option value="onion_btc">DeepOnion (ONION)</option>
         // <option value="btc_bhd">Bahraini Dinar (BHD)</option>

--- a/desktop/src/test/java/bisq/desktop/main/dao/monitor/daostate/DaoStateBlockListItemTest.java
+++ b/desktop/src/test/java/bisq/desktop/main/dao/monitor/daostate/DaoStateBlockListItemTest.java
@@ -34,7 +34,7 @@ public class DaoStateBlockListItemTest {
 
     @BeforeEach
     public void setup() {
-        Locale.setDefault(new Locale("en", "US"));
+        Locale.setDefault(Locale.of("en", "US"));
         Res.setBaseCurrencyCode("BTC");
         Res.setBaseCurrencyName("Bitcoin");
     }

--- a/desktop/src/test/java/bisq/desktop/util/CurrencyListTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/CurrencyListTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class CurrencyListTest {
-    private static final Locale locale = new Locale("en", "US");
+    private static final Locale locale = Locale.of("en", "US");
 
     private static final TradeCurrency USD = new FiatCurrency(Currency.getInstance("USD"), locale);
     private static final TradeCurrency RUR = new FiatCurrency(Currency.getInstance("RUR"), locale);

--- a/desktop/src/test/java/bisq/desktop/util/GUIUtilTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/GUIUtilTest.java
@@ -64,8 +64,8 @@ public class GUIUtilTest {
 
     @BeforeEach
     public void setup() {
-        Locale.setDefault(new Locale("en", "US"));
-        GlobalSettings.setLocale(new Locale("en", "US"));
+        Locale.setDefault(Locale.of("en", "US"));
+        GlobalSettings.setLocale(Locale.of("en", "US"));
         Res.setBaseCurrencyCode("BTC");
         Res.setBaseCurrencyName("Bitcoin");
         preferences = mock(Preferences.class);

--- a/desktop/src/test/java/bisq/desktop/util/ImmutableCoinFormatterTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/ImmutableCoinFormatterTest.java
@@ -43,7 +43,7 @@ public class ImmutableCoinFormatterTest {
 
     @BeforeEach
     public void setUp() {
-        Locale.setDefault(new Locale("en", "US"));
+        Locale.setDefault(Locale.of("en", "US"));
         Res.setBaseCurrencyCode("BTC");
         Res.setBaseCurrencyName("Bitcoin");
     }

--- a/desktop/src/test/java/bisq/desktop/util/validation/AccountNrValidatorTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/validation/AccountNrValidatorTest.java
@@ -13,7 +13,7 @@ public class AccountNrValidatorTest {
 
     @BeforeEach
     public void setup() {
-        Locale.setDefault(new Locale("en", "US"));
+        Locale.setDefault(Locale.of("en", "US"));
         Res.setBaseCurrencyCode("BTC");
         Res.setBaseCurrencyName("Bitcoin");
     }

--- a/desktop/src/test/java/bisq/desktop/util/validation/BranchIdValidatorTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/validation/BranchIdValidatorTest.java
@@ -14,7 +14,7 @@ public class BranchIdValidatorTest {
 
     @BeforeEach
     public void setup() {
-        Locale.setDefault(new Locale("en", "US"));
+        Locale.setDefault(Locale.of("en", "US"));
         Res.setBaseCurrencyCode("BTC");
         Res.setBaseCurrencyName("Bitcoin");
     }

--- a/desktop/src/test/java/bisq/desktop/util/validation/NationalAccountIdValidatorTest.java
+++ b/desktop/src/test/java/bisq/desktop/util/validation/NationalAccountIdValidatorTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class NationalAccountIdValidatorTest {
     @BeforeEach
     public void setup() {
-        Locale.setDefault(new Locale("en", "US"));
+        Locale.setDefault(Locale.of("en", "US"));
         Res.setBaseCurrencyCode("BTC");
         Res.setBaseCurrencyName("Bitcoin");
     }


### PR DESCRIPTION
All of Locale's constructors have been deprecated in Java 19. The recommended migration path is to call Locale.of with the same arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated locale setup across core and desktop test suites to use the modern locale creation method.
  * Preserved existing test behavior and assertions.
* **Chores**
  * Removed usage of deprecated locale constructors from test and utility setup code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->