### PR TITLE
Fix bank account validation order

### DIFF
--- a/desktop/src/main/java/bisq/desktop/components/paymentmethods/BankForm.java
+++ b/desktop/src/main/java/bisq/desktop/components/paymentmethods/BankForm.java
@@ -295,6 +295,8 @@ abstract class BankForm extends GeneralBankForm {
             accountNrInputTextField.setPromptText(BankUtil.getAccountNrLabel(countryCode));
             accountTypeComboBox.setPromptText(BankUtil.getAccountTypeLabel(countryCode));
 
+            validateInput(countryCode);
+
             bankNameInputTextField.setText("");
             bankIdInputTextField.setText("");
             branchIdInputTextField.setText("");
@@ -306,7 +308,6 @@ abstract class BankForm extends GeneralBankForm {
             accountTypeComboBox.getSelectionModel().clearSelection();
             accountTypeComboBox.setItems(FXCollections.observableArrayList(BankUtil.getAccountTypeValues(countryCode)));
 
-            validateInput(countryCode);
 
             holderNameInputTextField.resetValidation();
             holderNameInputTextField.validate();


### PR DESCRIPTION
Fixes #8037.

### What changed

Move `validateInput(countryCode)` before clearing the bank account input fields in `BankForm.onCountrySelected()`.

### Why

Clearing the fields triggers their listeners and `updateFromInputs()`, which can validate the account number before its country-specific validator has been assigned. For Australia, this caused a `NullPointerException` because `getValidator()` returned null.

### Verification

- Reproduced issue #8037 on Bisq v1.10.8.
- Confirmed the error occurred when entering details before selecting Oceania → Australia.
- After the change, the same flow no longer produces the error.
- `./gradlew :desktop:test` passes.
- `git diff --check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation timing when selecting a country in bank payment details.
  * Ensured country changes provide more consistent validation feedback while updating account fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->