### PR TITLE
core: Fix Charsets to StandardCharsets migration

### DIFF
--- a/core/src/test/java/bisq/core/account/sign/SignedWitnessServiceTest.java
+++ b/core/src/test/java/bisq/core/account/sign/SignedWitnessServiceTest.java
@@ -214,7 +214,7 @@ public class SignedWitnessServiceTest {
     public void provenOwnerDatesRejectInvalidArbitratorSignatureDespiteOwnerSwap() {
         SignedWitness forged = new SignedWitness(ARBITRATOR,
                 account1DataHash,
-                "invalid-arbitrator-signature".getBytes(Charsets.UTF_8),
+                "invalid-arbitrator-signature".getBytes(StandardCharsets.UTF_8),
                 signer1PubKey,
                 witnessOwner2PubKey,
                 date1,
@@ -689,7 +689,7 @@ public class SignedWitnessServiceTest {
     @Test
     public void publishRejectsAWitnessWithAnInvalidSignature() throws Exception {
         setupTrade();
-        byte[] invalidSignature = Sig.sign(peer1KeyPair.getPrivate(), "wrong-message".getBytes(Charsets.UTF_8));
+        byte[] invalidSignature = Sig.sign(peer1KeyPair.getPrivate(), "wrong-message".getBytes(StandardCharsets.UTF_8));
 
         assertFalse(publish(new SignedWitness(TRADE, account2DataHash, invalidSignature, signer2PubKey,
                 witnessOwner3PubKey, NOW - 1000, tradeAmount.value)));


### PR DESCRIPTION
During a recent rebase of the commit that replaced the deprecated Charsets.UTF_8 with StandardCharsets.UTF_8, some usages in newly added code were missed. This updates the remaining occurrences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated invalid-signature test data encoding to use the standard UTF-8 character set.
  * Existing test behavior and assertions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->