### PR TITLE
Skip the republish retry before bootstrap

### DIFF
--- a/core/src/main/java/bisq/core/offer/OpenOfferManager.java
+++ b/core/src/main/java/bisq/core/offer/OpenOfferManager.java
@@ -1248,6 +1248,22 @@ public class OpenOfferManager implements PeerManager.Listener, DecryptedDirectMe
                 },
                 errorMessage -> {
                     if (!stopped) {
+                        if (!offerBookService.isBootstrapped()) {
+                            // Retrying cannot change the outcome before the bootstrap, and
+                            // onBootstrapComplete republishes all open offers anyway. An armed
+                            // retry timer would also suppress the republish round which is
+                            // scheduled after the bootstrap only while no retry timer is set.
+                            log.warn("Adding offer to P2P network failed. We do not retry while the " +
+                                            "P2P network is not bootstrapped yet, as all open offers get " +
+                                            "republished after the bootstrap. offerId={}, errorMessage={}",
+                                    openOffer.getId(), errorMessage);
+
+                            if (completeHandler != null) {
+                                completeHandler.run();
+                            }
+                            return;
+                        }
+
                         log.error("Adding offer to P2P network failed. " + errorMessage);
                         stopRetryRepublishOffersTimer();
                         retryRepublishOffersTimer = UserThread.runAfter(OpenOfferManager.this::republishOffers,

--- a/core/src/test/java/bisq/core/offer/OpenOfferManagerTest.java
+++ b/core/src/test/java/bisq/core/offer/OpenOfferManagerTest.java
@@ -575,4 +575,115 @@ public class OpenOfferManagerTest {
         assertFalse(errorHandled.get());
     }
 
+    @Test
+    public void testMaybeRepublishOfferSkipsRetryWhileNotBootstrapped() {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        when(p2PService.getPeerManager()).thenReturn(mock(PeerManager.class));
+        OpenOfferManager manager = new OpenOfferManager(coreContext,
+                null,
+                null,
+                null,
+                p2PService,
+                null,
+                null,
+                null,
+                offerBookService,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                persistenceManager,
+                null
+        );
+
+        OpenOffer openOffer = new OpenOffer(make(btcUsdOffer));
+        manager.getObservableList().add(openOffer);
+
+        when(offerBookService.isBootstrapped()).thenReturn(false);
+        doAnswer(invocation -> {
+            ((ErrorMessageHandler) invocation.getArgument(2)).handleErrorMessage(
+                    "Add offer failed: the P2P network is not bootstrapped yet");
+            return null;
+        }).when(offerBookService).addOffer(any(Offer.class), any(ResultHandler.class), any(ErrorMessageHandler.class));
+
+        ManualTimer.clear();
+        UserThread.setTimerClass(ManualTimer.class);
+        try {
+            manager.maybeRepublishOffer(openOffer);
+            ManualTimer.firePendingTimers();
+
+            // No retry timer must be armed while the network is not bootstrapped: a retry
+            // cannot change the outcome, and firing it would republish every open offer and
+            // log another warning, every 10 seconds until the bootstrap completes.
+            verify(offerBookService, times(1)).addOffer(any(Offer.class),
+                    any(ResultHandler.class),
+                    any(ErrorMessageHandler.class));
+        } finally {
+            ManualTimer.clear();
+            UserThread.setTimerClass(FrameRateTimer.class);
+        }
+    }
+
+    @Test
+    public void testMaybeRepublishOfferRetriesWhenBootstrapped() {
+        P2PService p2PService = mock(P2PService.class);
+        OfferBookService offerBookService = mock(OfferBookService.class);
+        when(p2PService.getPeerManager()).thenReturn(mock(PeerManager.class));
+        OpenOfferManager manager = new OpenOfferManager(coreContext,
+                null,
+                null,
+                null,
+                p2PService,
+                null,
+                null,
+                null,
+                offerBookService,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                persistenceManager,
+                null
+        );
+
+        OpenOffer openOffer = new OpenOffer(make(btcUsdOffer));
+        manager.getObservableList().add(openOffer);
+
+        when(offerBookService.isBootstrapped()).thenReturn(true);
+        doAnswer(invocation -> {
+            ((ErrorMessageHandler) invocation.getArgument(2)).handleErrorMessage("Add offer failed");
+            return null;
+        }).when(offerBookService).addOffer(any(Offer.class), any(ResultHandler.class), any(ErrorMessageHandler.class));
+
+        ManualTimer.clear();
+        UserThread.setTimerClass(ManualTimer.class);
+        try {
+            manager.maybeRepublishOffer(openOffer);
+            ManualTimer.firePendingTimers();
+
+            // A failure on a bootstrapped node can be transient, so the retry stays.
+            verify(offerBookService, times(2)).addOffer(any(Offer.class),
+                    any(ResultHandler.class),
+                    any(ErrorMessageHandler.class));
+        } finally {
+            ManualTimer.clear();
+            UserThread.setTimerClass(FrameRateTimer.class);
+        }
+    }
+
 }


### PR DESCRIPTION
An API edit that re-enables a deactivated offer is reachable before the
P2P network is bootstrapped: the daemon reads the persisted open offers
and starts the gRPC server before BisqSetup begins the P2P setup, and
editoffer requires neither a wallet nor a bootstrapped network. addOffer
then reports "the P2P network is not bootstrapped yet" through the error
handler, which stops and re-arms the retry timer unconditionally. That
republishes every open offer every 10 seconds, logging an error per
offer, for as long as the bootstrap takes, and forever if it never
completes.

Retrying cannot change the outcome there, since only the bootstrap can,
and onBootstrapComplete republishes all open offers anyway. The armed
timer also suppresses the second republish round scheduled 30 seconds
after that one, which is armed only while no retry timer is set.

Skip the retry while the offer book is not bootstrapped and report the
failure as a warning naming the offer, matching maybeRefreshOffer, whose
error handler for the same condition is a plain log.warn with no retry.
A failure on a bootstrapped node keeps the error log and the retry.

P2PService.isBootstrapped is assigned once, inside applyIsBootstrapped,
and is never reset, and the flag is set before the P2P listeners are
notified. So onBootstrapComplete always runs with the flag true and
republishes every open offer, and the reconnect path
(onAllConnectionsLost / restart) runs only after the bootstrap, so it
keeps its retry unchanged.

Only testMaybeRepublishOfferSkipsRetryWhileNotBootstrapped is a
regression test: it fails on master with two addOffer calls instead of
one. testMaybeRepublishOfferRetriesWhenBootstrapped passes on master and
is there to keep the guard narrow. The log level itself is not asserted,
as the repo has no log capture helper.

No specification change: the contract is already stated in
docs/specifications/offer/offer-edit-and-removal.md, which says that a
publish failure before the bootstrap does not fail the edit and that the
offer is published by the republish that follows the bootstrap. The
retry schedule and the log level are implementation.

Follow-up to the review of #8021.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved offer republishing after failed publication attempts.
  - Avoided unnecessary retry attempts while the peer-to-peer network is not bootstrapped.
  - Continued processing subsequent offers when network availability changes.
  - Preserved retry behavior once the network is bootstrapped.
  - Completed offer processing cleanly when publication cannot proceed due to unavailable network readiness.

- **Tests**
  - Added coverage for republishing before and after network initialization, including continued offer processing when retries are skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->