### PR TITLE
Reject payment started without seller account

### DIFF
--- a/core/src/main/java/bisq/core/api/CoreTradesService.java
+++ b/core/src/main/java/bisq/core/api/CoreTradesService.java
@@ -202,6 +202,19 @@ class CoreTradesService {
                                 trade.getId(),
                                 trade.getDepositTxId()));
             }
+
+            // Without the seller's payment account payload the buyer has no details to pay
+            // to, so a payment started message would tell the seller a payment happened that
+            // cannot have happened. The desktop client disables its confirm button on the
+            // same condition.
+            if (trade.getContract() == null
+                    || trade.getContract().getSellerPaymentAccountPayload() == null) {
+                throw new FailedPreconditionException(
+                        format("cannot send a payment started message for trade '%s'%n"
+                                        + "until the seller's payment account details have been received",
+                                trade.getId()));
+            }
+
             // pass along counter currency tx proof info if provided
             if (txId != null && txKey != null && !txId.isEmpty() && !txKey.isEmpty()) {
                 trade.setCounterCurrencyTxId(txId);

--- a/core/src/test/java/bisq/core/api/CoreTradesServiceConfirmPaymentStartedTest.java
+++ b/core/src/test/java/bisq/core/api/CoreTradesServiceConfirmPaymentStartedTest.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.api;
+
+import bisq.core.api.exception.FailedPreconditionException;
+import bisq.core.btc.wallet.BtcWalletService;
+import bisq.core.offer.OfferUtil;
+import bisq.core.offer.bisq_v1.TakeOfferModel;
+import bisq.core.offer.bsq_swap.BsqSwapTakeOfferModel;
+import bisq.core.payment.payload.PaymentAccountPayload;
+import bisq.core.trade.ClosedTradableFormatter;
+import bisq.core.trade.ClosedTradableManager;
+import bisq.core.trade.TradeManager;
+import bisq.core.trade.bisq_v1.FailedTradesManager;
+import bisq.core.trade.bisq_v1.TradeUtil;
+import bisq.core.trade.bsq_swap.BsqSwapTradeManager;
+import bisq.core.trade.model.bisq_v1.Contract;
+import bisq.core.trade.model.bisq_v1.Trade;
+import bisq.core.trade.protocol.bisq_v1.BuyerProtocol;
+import bisq.core.user.User;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CoreTradesServiceConfirmPaymentStartedTest {
+    private static final String TRADE_ID = "tradeId";
+
+    private CoreTradesService coreTradesService;
+    private Trade trade;
+    private Contract contract;
+    private BuyerProtocol buyerProtocol;
+
+    @BeforeEach
+    void setUp() {
+        TradeManager tradeManager = mock(TradeManager.class);
+        trade = mock(Trade.class);
+        contract = mock(Contract.class);
+        buyerProtocol = mock(BuyerProtocol.class);
+
+        when(trade.getId()).thenReturn(TRADE_ID);
+        when(trade.isDepositConfirmed()).thenReturn(true);
+        when(tradeManager.getTradeById(TRADE_ID)).thenReturn(Optional.of(trade));
+        when(tradeManager.getTradeProtocol(trade)).thenReturn(buyerProtocol);
+
+        coreTradesService = new CoreTradesService(new CoreContext(),
+                mock(CoreWalletsService.class),
+                mock(BtcWalletService.class),
+                mock(OfferUtil.class),
+                mock(BsqSwapTradeManager.class),
+                mock(ClosedTradableManager.class),
+                mock(ClosedTradableFormatter.class),
+                mock(FailedTradesManager.class),
+                mock(TakeOfferModel.class),
+                mock(BsqSwapTakeOfferModel.class),
+                tradeManager,
+                mock(TradeUtil.class),
+                mock(User.class));
+    }
+
+    @Test
+    void missingSellerPaymentAccountPayloadIsRejected() {
+        when(trade.getContract()).thenReturn(contract);
+        when(contract.getSellerPaymentAccountPayload()).thenReturn(null);
+
+        assertThrows(FailedPreconditionException.class,
+                () -> coreTradesService.confirmPaymentStarted(TRADE_ID, "txId", "txKey"));
+        verify(buyerProtocol, never()).onPaymentStarted(any(), any());
+        verify(trade, never()).setCounterCurrencyTxId(any());
+        verify(trade, never()).setCounterCurrencyExtraData(any());
+    }
+
+    @Test
+    void missingContractIsRejected() {
+        // The contract is set during the take offer handshake, so this is not the missing
+        // message case; Trade.contract is @Nullable and the payload access would NPE.
+        when(trade.getContract()).thenReturn(null);
+
+        assertThrows(FailedPreconditionException.class,
+                () -> coreTradesService.confirmPaymentStarted(TRADE_ID, null, null));
+        verify(buyerProtocol, never()).onPaymentStarted(any(), any());
+    }
+
+    @Test
+    void presentSellerPaymentAccountPayloadStartsPayment() {
+        when(trade.getContract()).thenReturn(contract);
+        when(contract.getSellerPaymentAccountPayload()).thenReturn(mock(PaymentAccountPayload.class));
+
+        coreTradesService.confirmPaymentStarted(TRADE_ID, null, null);
+
+        verify(buyerProtocol).onPaymentStarted(any(), any());
+    }
+}


### PR DESCRIPTION
CoreTradesService.confirmPaymentStarted checks only that the trade has
not failed and that its deposit tx is confirmed. Neither says anything
about the seller's payment account payload, which reaches the buyer
with the DepositTxAndDelayedPayoutTxMessage and can be absent on a
trade whose deposit the buyer confirmed from the wallet alone.

None of the five tasks in BuyerProtocol.onPaymentStarted reads that
payload: ApplyFilter treats it as nullable, the fee verification tasks
are no-ops, and the payout tasks use the contract only for addresses
and multisig keys. So the call succeeds, the trade moves to FIAT_SENT
and the payment started message goes to the seller for a payment the
buyer had no details to make.

FIAT_SENT is also past every phase in which the buyer still accepts
the DepositTxAndDelayedPayoutTxMessage, so the confirm closes the last
window in which the missing payload could still arrive.

Reject the call while the contract carries no seller payment account
payload. The check sits before the counter currency tx proof is
stored, so a rejected confirmpaymentstartedxmr leaves no proof data on
the trade.

The desktop client refuses the same state since #7955, which disables
the confirm button on the same contract payload.

Both rejection tests fail on master: without the guard the call reaches
onPaymentStarted and stores the tx proof. The third test covers the
normal path, so the guard cannot be widened unnoticed.

A precondition in BuyerProtocol would not work for this: FluentProtocol
returns before the task runner is built, so the gRPC caller would still
get an OK. A first task in onPaymentStarted would cover both clients,
but it runs after the phase is set and its failure writes an error
message on the trade, so it is a protocol change rather than the guard
this follow-up was about.

No specification change: this is a client-side precondition, not a rule
of the trade protocol, and neither of the two merged PRs for this issue
carried one.

Part of #7945

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Payment-start confirmation is now rejected when required trade or seller payment details are missing.
  - Prevents payment-start actions from occurring when confirmation data is incomplete.
  - Valid payment-start confirmations continue to be processed successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->