### PR TITLE
Initialize trusted block providers only once

### DIFF
--- a/core/src/main/java/bisq/core/dao/node/block_provider/TrustedBsqBlockProviderRepository.java
+++ b/core/src/main/java/bisq/core/dao/node/block_provider/TrustedBsqBlockProviderRepository.java
@@ -33,7 +33,6 @@ import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -48,9 +47,10 @@ import lombok.extern.slf4j.Slf4j;
 public class TrustedBsqBlockProviderRepository {
     private static final String POSTFIX = ".trusted_bsq_block_providers";
 
-    private final Set<TrustedBsqBlockProvider> trustedBsqBlockProviders = new HashSet<>();
     private final Config config;
     private final DenyList denyList;
+    private Set<TrustedBsqBlockProvider> trustedBsqBlockProviders = Set.of();
+    private boolean initialized;
 
     @Inject
     public TrustedBsqBlockProviderRepository(Config config, DenyList denyList) {
@@ -63,8 +63,8 @@ public class TrustedBsqBlockProviderRepository {
     }
 
 
-    public Collection<TrustedBsqBlockProvider> getTrustedBsqBlockProviders() {
-        if (trustedBsqBlockProviders.isEmpty()) {
+    public synchronized Collection<TrustedBsqBlockProvider> getTrustedBsqBlockProviders() {
+        if (!initialized) {
             lazyInitialize();
         }
 
@@ -99,8 +99,8 @@ public class TrustedBsqBlockProviderRepository {
                     .filter(Objects::nonNull)
                     .filter(provider -> !deniedNodeAddresses.contains(provider.getNodeAddress()))
                     .collect(Collectors.toSet());
-            trustedBsqBlockProviders.clear();
-            trustedBsqBlockProviders.addAll(providers);
+            trustedBsqBlockProviders = Set.copyOf(providers);
+            initialized = true;
         } catch (Exception t) {
             log.error("Failed to initialize trustedBsqBlockProviders", t);
             throw t;

--- a/core/src/test/java/bisq/core/dao/node/block_provider/TrustedBsqBlockProviderRepositoryTest.java
+++ b/core/src/test/java/bisq/core/dao/node/block_provider/TrustedBsqBlockProviderRepositoryTest.java
@@ -17,6 +17,8 @@
 
 package bisq.core.dao.node.block_provider;
 
+import bisq.core.filter.DenyList;
+
 import bisq.network.p2p.NodeAddress;
 
 import bisq.common.config.Config;
@@ -27,6 +29,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 import static java.lang.String.format;
@@ -35,7 +38,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TrustedBsqBlockProviderRepositoryTest {
     private static final String MAINNET = format("--%s=%s", Config.BASE_CURRENCY_NETWORK, "btc_mainnet");
@@ -126,6 +134,27 @@ public class TrustedBsqBlockProviderRepositoryTest {
         assertNull(provider.getRole());
         assertDoesNotThrow(() -> Sig.getPublicKeyFromBytes(provider.getEncodedPublicKey()));
         assertFalse(isTrusted(trustedFullDaoNodes, bundledProviderAddress));
+    }
+
+    @Test
+    public void initializesOnlyOnceWhenNoProvidersAreLoaded() {
+        DenyList denyList = mock(DenyList.class);
+        when(denyList.getBannedSeedNodes()).thenReturn(List.of());
+        TrustedBsqBlockProviderRepository trustedFullDaoNodes =
+                new TrustedBsqBlockProviderRepository(new Config(REGTEST), denyList);
+
+        assertTrue(trustedFullDaoNodes.getTrustedBsqBlockProviders().isEmpty());
+        assertTrue(trustedFullDaoNodes.getTrustedBsqBlockProviders().isEmpty());
+
+        verify(denyList, times(1)).getBannedSeedNodes();
+    }
+
+    @Test
+    public void returnsUnmodifiableProviders() {
+        TrustedBsqBlockProviderRepository trustedFullDaoNodes = new TrustedBsqBlockProviderRepository(new Config(MAINNET));
+        Collection<TrustedBsqBlockProvider> providers = trustedFullDaoNodes.getTrustedBsqBlockProviders();
+
+        assertThrows(UnsupportedOperationException.class, providers::clear);
     }
 
     @AfterEach


### PR DESCRIPTION
Fixes #7973 — the review comment it points to:
https://github.com/bisq-network/bisq/pull/7966#discussion_r3653946833

`getTrustedBsqBlockProviders()` used the emptiness of the provider set as its lazy initialization guard. An empty set is a legitimate outcome: regtest bundles no providers, the resource file can be absent, and the deny list may filter out every entry. In those cases, `lazyInitialize()` ran again on every call, re-reading the resource on a path that `DaoBlockSignatureVerifier` walks per block.

Populating the set in place also handed callers a live reference to it, and left it briefly empty between `clear()` and `addAll()`. Every caller reaches this singleton on the user thread today, so that window is not observable in practice, but nothing in the class enforces it.

Track initialization in an explicit flag, synchronize the accessor, and publish the providers as an immutable set, so the guard is atomic and callers cannot mutate shared state.



Two new tests cover this; both fail without the production change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved trusted block provider loading so initialization occurs reliably and only once, including when no providers are available.
  - Prevented accidental modification of the trusted provider list after it has been loaded.
  - Improved consistency when accessing trusted block provider information from multiple operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->